### PR TITLE
docs: add mutation testing concept page and fix gremlins URLs

### DIFF
--- a/doc/docs/changelog.md
+++ b/doc/docs/changelog.md
@@ -5,6 +5,36 @@ All notable changes to go-crap will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.0 (unreleased)
+
+### Added
+
+- New `--mutation-report` flag — path to a gremlins JSON mutation report to validate coverage reliability
+- New `internal/mutation` package — parses gremlins mutation reports and annotates CRAP entries
+- New `CoverageUntrusted` field on `CRAPEntry` — set to `true` when lived mutants are found in a function
+- New `MutationScore` field on `CRAPEntry` — killed/(killed+lived) ratio for the function
+- New `EffectiveCRAP` field on `CRAPEntry` — CRAP score recalculated with 0% coverage when `CoverageUntrusted` is `true`
+- Mutation score included in JSON output (`mutation_score`, `coverage_untrusted`, `effective_crap` fields)
+- Coverage warning flag (⚠) in `table` and `pr-comment` formatters when coverage is unreliable
+- Coverage-untrusted warnings in `github` and `sarif` formatters (SARIF adds a second `coverage-untrusted` result)
+- New "Unreliable Coverage" section in `pr-comment` output listing affected functions with mutation scores
+- New `--detailed` flag — includes mutation failure details (original/replacement code, line, type) in report output
+- New `MutationDetail` struct on `CRAPEntry` — stores survived mutant details when mutation report is provided
+- JSON output includes `mutation_details` array per entry when `--detailed` is set, with `type`, `mutator_name`, `file`, `line`, `status`, `original_text`, and `replacement_text` fields
+- SARIF appends survived mutation details (type, line, code diff) to warning messages when `--detailed`
+- PR Comment adds `Survived Mutants` column with code snippets when `--detailed`
+- New `OriginalCode` and `ReplacementCode` fields on mutation `Mutant` struct, parsed from Gremlins JSON report
+
+### Changed
+
+- `ThresholdExceeded()` now uses `EffectiveCRAP` instead of `CRAP` for threshold comparison
+- Filtering (`--top`, `--min`) and sorting now use `EffectiveCRAP` when mutation report is provided
+- `--fail-above` now checks `EffectiveCRAP` against the threshold
+
+### Fixed
+
+- Functions with lived mutants now show their true risk level via `EffectiveCRAP` (CRAP at 0% coverage)
+
 ## v0.3.0 - 2026-06-05
 
 ### Added

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -27,6 +27,8 @@ go-crap scan [path] [flags]
 | `--exclude` | | Exclude files matching this regex pattern (repeatable). Use `.*` to match any path depth. e.g. `.*_test\.go` to exclude all test files, `pb/.*\.go` to exclude protobuf files | none |
 | `--verbose` | | Enable verbose (debug-level) logging | `false` |
 | `--output` | `-o` | Output file path (default: stdout) | stdout |
+| `--mutation-report` | | Path to gremlins JSON mutation report to validate coverage reliability | `""` (disabled) |
+| `--detailed` | | Include mutation failure details (original/replacement code, line, type) in report output | `false` |
 
 ## Examples
 
@@ -110,3 +112,35 @@ go-crap scan --verbose
 ```
 
 Enables debug-level logging to help diagnose issues with module discovery, coverage parsing, or path matching.
+
+### Mutation report validation
+
+```shell
+go-crap scan --mutation-report gremlins-report.json
+```
+
+Validates coverage reliability by comparing mutation testing results against go-crap's coverage data. When a function has **lived** mutants (mutations that survived because tests didn't catch them), go-crap marks the coverage as unreliable and recalculates the CRAP score assuming 0% coverage.
+
+Unreliable coverage is indicated by:
+
+- A ⚠ warning next to the coverage percentage in `table` and `pr-comment` output
+- An additional `coverage-untrusted` SARIF result in `sarif` format
+- A mutation score in `json` output (`mutation_score` field)
+- An "Unreliable Coverage" section in `pr-comment` output listing all affected functions
+
+This is useful when you use [gremlins](https://github.com/go-gremlins/gremlins) or similar mutation testing tools to catch functions that appear well-tested but have blind spots.
+
+### Detailed mutation output
+
+```shell
+go-crap scan --mutation-report gremlins-report.json --format json --detailed
+```
+
+The `--detailed` flag includes full mutation failure details in the report output:
+
+- **JSON**: `mutation_details` array per entry with `type`, `mutator_name`, `file`, `line`, `status`, `original_text`, `replacement_text`
+- **SARIF**: survived mutations appended to warning messages with type, line, and code diff (e.g. `"a < b" → "a >= b"`)
+- **PR Comment**: `Survived Mutants` column in the Unreliable Coverage section, with code snippets inline
+- **Table**: no change — still shows ⚠ for untrusted coverage
+
+This is useful for debugging which specific mutants survived and what code transformations they represented.

--- a/doc/docs/concepts/mutation-testing.md
+++ b/doc/docs/concepts/mutation-testing.md
@@ -1,0 +1,138 @@
+## Mutation Testing
+
+Mutation testing evaluates the quality of your tests by injecting small, deliberate changes (called **mutants**) into your source code and running tests to see if they catch them.
+
+A mutant that gets caught by tests is **killed** — meaning your test caught the change. A mutant that survives means your tests have a blind spot: the code path was never meaningfully asserted.
+
+Coverage alone can lie. A function with 100% line coverage can still have untested logical paths. Mutation testing catches that gap.
+
+## Gremlins
+
+[Gremlins](https://gremlins.dev/latest/) is a mutation testing tool for Go that go-crap integrates with via JSON reports.
+
+### Installation
+
+```shell
+go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
+```
+
+### Generating a report
+
+```shell
+gremlins unleash --output=gremlins-report.json
+```
+
+Gremlins supports multiple mutators: conditional boundaries, increments, logical operators, function calls, and more. See the [Gremlins documentation](https://gremlins.dev/latest/) for the full list and configuration options.
+
+## Mutation reports with go-crap
+
+Use the `--mutation-report` flag to pass a gremlins JSON report to go-crap. go-crap matches mutants to functions by file and line range, then:
+
+1. Counts **killed** vs **lived** mutants within each function's line range
+2. If any mutant **lived** → coverage is marked **untrusted** → CRAP recalculated assuming 0% coverage
+3. Computes `mutation_score` = `killed / (killed + lived)`
+
+```shell
+go-crap scan --mutation-report gremlins-report.json
+```
+
+Use `--detailed` alongside `--mutation-report` to include per-mutant details (type, line, original/replacement code):
+
+```shell
+go-crap scan --mutation-report gremlins-report.json --format json --detailed
+```
+
+### How mutation data surfaces in each format
+
+| Format | Mutation indicator |
+|--------|-------------------|
+| `table` | ⚠ flag next to coverage percentage |
+| `json` | `mutation_score`, `coverage_untrusted`, `mutation_details` array |
+| `sarif` | `coverage-untrusted` result; survived mutations with code diffs appended to warning messages |
+| `pr-comment` | "Unreliable Coverage" section + "Survived Mutants" column with inline code snippets |
+
+## CI integration
+
+### GitHub Actions
+
+```yaml
+name: mutation
+on: [push, pull_request]
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
+      - name: Install go-crap
+        run: go install github.com/padiazg/go-crap@latest
+      - name: Run mutation testing
+        run: gremlins unleash --output=gremlins-report.json
+      - name: Run go-crap with mutation validation
+        run: go-crap scan --mutation-report gremlins-report.json --fail-above --threshold 30
+```
+
+See [CI Workflows](../integrations/ci.md) for platform-specific examples with SARIF, PR comments, and matrix builds.
+
+## Interpreting results
+
+### `effective_crap` vs `crap`
+
+When no survived mutants exist, `effective_crap` equals `crap`. When mutants survived, `effective_crap` is recalculated assuming 0% coverage — reflecting the true risk of untested logic.
+
+### Finding survived mutants
+
+```shell
+# Survived mutants per function
+go-crap scan --mutation-report gremlins-report.json --format json --detailed | \
+  jq '.entries[] | select(.mutation_details != null) | {file, function, mutation_details}'
+
+# Summary of mutation scores
+go-crap scan --mutation-report gremlins-report.json --format json | \
+  jq '[.entries[] | select(.coverage_untrusted == true)] | length'
+```
+
+A `mutation_score` of 1.0 means all mutants were killed. A score near 0 means most survived — coverage in that function is unreliable.
+
+### Gremlins report format
+
+go-crap expects the JSON structure produced by `gremlins unleash`:
+
+```json
+{
+  "go_module": "github.com/org/repo",
+  "files": [
+    {
+      "file_name": "internal/pkg/foo.go",
+      "mutations": [
+        {
+          "type": "CONDITIONALS_BOUNDARY",
+          "mutator": "CB",
+          "file": "internal/pkg/foo.go",
+          "line": 42,
+          "status": "LIVED",
+          "original_code": "a < b",
+          "replacement_code": "a >= b"
+        }
+      ]
+    }
+  ],
+  "mutants_killed": 10,
+  "mutants_lived": 2,
+  "mutants_not_covered": 0,
+  "mutants_total": 12,
+  "test_efficacy": 0.833
+}
+```
+
+Mutants are matched to functions by file path and line range. A mutant within a function's start-to-end line range is attributed to that function.
+
+## Future compatibility
+
+Other mutation testing tools like [ooze](https://github.com/gtramontina/ooze) could be supported in the future. Current support is gremlins-only since other alternatives are unmaintained.

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -25,6 +25,26 @@ A high CRAP score means the function is complex *and* poorly tested - it's a pri
 
 → [CRAP Score Formula](concepts/crap-score.md)
 
+### Mutation Validation
+
+Coverage percentage alone doesn't guarantee test quality. A function with 100% coverage can still have blind spots — paths that are never executed by tests.
+
+The `--mutation-report` flag validates coverage reliability by comparing mutation testing results (from [gremlins](https://github.com/go-gremlins/gremlins) or similar tools) against go-crap's coverage data. When a function has **lived** mutants, go-crap marks the coverage as unreliable and recalculates the CRAP score assuming 0% coverage.
+
+This is surfaced in output via:
+- ⚠ warning flag in `table` and `pr-comment` formatters
+- Coverage-untrusted SARIF result in `sarif` format
+- `mutation_score` and `coverage_untrusted` fields in `json` output
+- "Unreliable Coverage" section in `pr-comment` output
+
+### Detailed Mutation Details
+
+The `--detailed` flag includes full mutation failure details in report output. Each survived mutant includes its type, line number, and the original/replacement code that was mutated.
+
+- **JSON**: `mutation_details` array per entry with full mutant info
+- **SARIF**: survived mutations with code diffs appended to warning messages
+- **PR Comment**: `Survived Mutants` column with inline code snippets
+
 ### Missing Coverage Policy
 
 When a function has no coverage data, go-crap can handle it three ways:

--- a/doc/docs/integrations/ci.md
+++ b/doc/docs/integrations/ci.md
@@ -315,6 +315,19 @@ go-crap scan --fail-above --threshold 15
 
 Use `--verbose` when diagnosing issues with module discovery, coverage parsing, or path matching in CI environments.
 
+### Mutation report with CI
+
+```yaml
+      - name: Install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
+      - name: Run mutation testing
+        run: gremlins unleash --output=gremlins-report.json
+      - name: Run go-crap with mutation validation
+        run: go-crap scan --mutation-report gremlins-report.json --fail-above --threshold 30
+      - name: Generate detailed report
+        run: go-crap scan --mutation-report gremlins-report.json --format json --detailed > crap-detailed.json
+```
+
 ### Report parsing
 
 The JSON output follows this schema:
@@ -331,7 +344,28 @@ The JSON output follows this schema:
       "line": 42,
       "cyclomatic": 8,
       "coverage": 0.25,
-      "crap": 125.0
+      "crap": 125.0,
+      "coverage_untrusted": false,
+      "mutation_score": 0.8,
+      "effective_crap": 125.0
+    }
+  ]
+}
+```
+
+When `--detailed` is used alongside `--mutation-report`, each entry with survived mutants includes a `mutation_details` array:
+
+```json
+{
+  "mutation_details": [
+    {
+      "type": "CONDITIONALS_BOUNDARY",
+      "mutator_name": "CB",
+      "file": "internal/pkg/foo.go",
+      "line": 50,
+      "status": "LIVED",
+      "original_text": "a < b",
+      "replacement_text": "a >= b"
     }
   ]
 }

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
     - Overview: concepts/index.md
     - CRAP Score: concepts/crap-score.md
     - Missing Coverage Policy: concepts/missing-policy.md
+    - Mutation Testing: concepts/mutation-testing.md
   - Commands:
     - commands/scan.md
   - Integrations:


### PR DESCRIPTION
# feat: mutation testing integration via gremlins

## Summary

Integrates gremlins (https://github.com/go-gremlins/gremlins) mutation testing reports with go-crap. When a gremlins JSON report is provided, go-crap validates coverage reliability by matching survived mutants against function line ranges, marking coverage as untrusted when mutants survived, and recalculating CRAP assuming 0% coverage.

## What's new

- internal/mutation/ — new package for parsing gremlins JSON reports and annotating CRAP entries with mutation data
- --mutation-report flag on scan — path to a gremlins mutation report JSON file
- --detailed flag on scan — includes per-mutant details (type, line, original/replacement code) in output
- Updated all formatters (json, sarif, table, pr-comment, github) to surface mutation information

## How it works

1. Gremlins injects small code changes and runs tests, producing a JSON report of killed vs survived mutants
2. go-crap parses the report, matches mutants to functions by file path + line range
3. If any mutant lived inside a function → coverage marked coverage_untrusted → effective_crap recalculated as CRAP(complexity, 0)
4. mutation_score = killed / (killed + lived) is included in output

## Output

| Format | Mutation indicator |
| - | - |
| table | ⚠ flag next to coverage |
| json | mutation_score, coverage_untrusted, mutation_details array |
| sarif | coverage-untrusted result + survived mutations with code diffs |
| pr-comment | "Unreliable Coverage" section + "Survived Mutants" column |

## Docs

- doc/docs/concepts/mutation-testing.md — new concept page covering gremlins setup, CI integration, interpreting results
- Updated CI workflows, scan command reference, and homepage with mutation testing examples
- Fixed gremlins URL references across docs (predich/gremlins → go-gremlins/gremlins)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Chore

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
