### PR TITLE
Added documentation for Github readme CRAP badge

### DIFF
--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -1,7 +1,7 @@
 name: crap
 on: 
   push:
-    branches-ignore: [master]
+    branches: [master]
   pull_request:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/padiazg/go-crap.svg)](https://pkg.go.dev/github.com/padiazg/go-crap)
 [![Go Report Card](https://goreportcard.com/badge/github.com/padiazg/go-crap)](https://goreportcard.com/report/github.com/padiazg/go-crap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CRAP analysis](https://github.com/padiazg/go-crap/actions/workflows/crap.yml/badge.svg?branch=master)](https://github.com/padiazg/go-crap/actions/workflows/crap.yml)
 
 CRAP score calculator for Go projects. Calculates the CRAP score (cyclomatic complexity × coverage) for every function in a Go module. Inspired by [cargo-crap](https://github.com/Boehs/cargo-crap) for Rust.
 
@@ -177,6 +178,16 @@ go-crap scan
 - `--mutation-report` validates coverage reliability against mutation testing results
 - `--detailed` includes mutation failure details (code, line, type) in report output
 - Coverage-unavailable warnings are emitted for modules where `go test` fails
+
+### Badge
+
+Add a status badge to your `README.md` to show the latest master analysis:
+
+```markdown
+[![CRAP analysis](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/crap.yml/badge.svg?branch=master)](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/crap.yml)
+```
+
+Requires the workflow to trigger on `push: branches: [master]` (not `branches-ignore`).
 
 ## Prior art and references
 

--- a/doc/docs/integrations/github-actions.md
+++ b/doc/docs/integrations/github-actions.md
@@ -1,5 +1,21 @@
 # GitHub Actions
 
+## Badge
+
+Show the latest master status in your `README.md`:
+
+```markdown
+[![CRAP analysis](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/crap.yml/badge.svg?branch=master)](https://github.com/YOUR_ORG/YOUR_REPO/actions/workflows/crap.yml)
+```
+
+The badge reflects the workflow result on `master`. Make sure the workflow triggers on that branch:
+
+```yaml
+on:
+  push:
+    branches: [master]
+```
+
 ## Fail on high CRAP scores
 
 ```yaml

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -18,8 +18,8 @@ import (
 
 // Sentinel errors.
 var (
-	ErrUnknownPolicy      = errors.New("unknown missing policy")
-	ErrThresholdExceeded  = errors.New("CRAP threshold exceeded")
+	ErrUnknownPolicy     = errors.New("unknown missing policy")
+	ErrThresholdExceeded = errors.New("CRAP threshold exceeded")
 )
 
 type Options struct {


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [*] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

Adds documentation for enabling CRAP badge at Github readme

## Related issues

Closes #

## Checklist
- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed
