### PR TITLE
fix: remove coverage profile temp files after successful scan

### DIFF
--- a/internal/coverage/parser.go
+++ b/internal/coverage/parser.go
@@ -28,6 +28,7 @@ type ModuleCoverage struct {
 	Error      error
 	Dir        string
 	ModulePath string
+	Profile    string
 	Functions  []FunctionCoverage
 }
 

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -128,6 +128,11 @@ func (s *Scanner) scanModule(ctx context.Context, modDir string) (ModuleCoverage
 		mc.Error = fmt.Errorf("runTests: %w", err)
 		return mc, mc.Error
 	}
+	defer func() {
+		if removeErr := os.Remove(profile); removeErr != nil {
+			s.Logger.Debug("coverage scan: remove temp file error", "profile", profile, "error", removeErr.Error())
+		}
+	}()
 
 	functions, err := parseCoverProfile(profile, modDir, modulePath)
 	if err != nil {

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -123,18 +123,18 @@ func (s *Scanner) scanModule(ctx context.Context, modDir string) (ModuleCoverage
 	}
 
 	mc.ModulePath = modulePath
-	profile, err := s.runTests(ctx, modDir)
+	mc.Profile, err = s.runTests(ctx, modDir)
 	if err != nil {
 		mc.Error = fmt.Errorf("runTests: %w", err)
 		return mc, mc.Error
 	}
 	defer func() {
-		if removeErr := os.Remove(profile); removeErr != nil {
-			s.Logger.Debug("coverage scan: remove temp file error", "profile", profile, "error", removeErr.Error())
+		if removeErr := os.Remove(mc.Profile); removeErr != nil {
+			s.Logger.Debug("coverage scan: remove temp file error", "profile", mc.Profile, "error", removeErr.Error())
 		}
 	}()
 
-	functions, err := parseCoverProfile(profile, modDir, modulePath)
+	functions, err := parseCoverProfile(mc.Profile, modDir, modulePath)
 	if err != nil {
 		mc.Error = fmt.Errorf("parseCoverProfile: %w", err)
 		return mc, mc.Error

--- a/internal/coverage/scanner_test.go
+++ b/internal/coverage/scanner_test.go
@@ -353,6 +353,28 @@ func TestScanner_scanModule(t *testing.T) {
 			},
 		},
 		{
+			name: "module_with_tests_removes_temp_profile",
+			checks: checkScannerscanModule(
+				func(t *testing.T, r ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					leaked, globErr := filepath.Glob(filepath.Join(os.TempDir(), "coverage-*.out"))
+					require.NoError(t, globErr)
+					assert.Empty(t, leaked, "coverage profile temp file(s) not cleaned up: %v", leaked)
+				},
+			),
+			before: func(s *Scanner) {
+				cwd, err := os.Getwd()
+				require.NoError(t, err)
+				projRoot := filepath.Dir(filepath.Dir(cwd))
+				srcDir := filepath.Join(projRoot, "internal", "testdata")
+				tempDir := t.TempDir()
+				copyFiles(t, srcDir, tempDir, "cover.out")
+				s.Path = tempDir
+				s.Timeout = 2 * time.Minute
+			},
+		},
+		{
 			name: "module_with_failed_tests",
 			checks: checkScannerscanModule(
 				func(t *testing.T, r ModuleCoverage, err error) {

--- a/internal/coverage/scanner_test.go
+++ b/internal/coverage/scanner_test.go
@@ -358,9 +358,8 @@ func TestScanner_scanModule(t *testing.T) {
 				func(t *testing.T, r ModuleCoverage, err error) {
 					t.Helper()
 					assert.NoError(t, err)
-					leaked, globErr := filepath.Glob(filepath.Join(os.TempDir(), "coverage-*.out"))
-					require.NoError(t, globErr)
-					assert.Empty(t, leaked, "coverage profile temp file(s) not cleaned up: %v", leaked)
+					_, err = os.Stat(r.Profile)
+					assert.ErrorIs(t, err, os.ErrNotExist, "coverage profile temp file(s) not cleaned up: %s", r.Profile)
 				},
 			),
 			before: func(s *Scanner) {
@@ -575,6 +574,11 @@ func Something() {}
 			}
 			ctx := context.Background()
 			r, err := s.runTests(ctx, modDir)
+			defer func() {
+				if removeErr := os.Remove(r); removeErr != nil {
+					assert.NoError(t, removeErr)
+				}
+			}()
 			if tt.wantErr != "" {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tt.wantErr)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

`Scanner.runTests` creates a temp coverage profile with `os.CreateTemp` but only removed it on the `cmd.Run()` error path. On success, the file was returned, consumed by `parseCoverProfile`, and never deleted — leaking one `coverage-*.out` file per successful module scan into the OS temp directory on every `go-crap` invocation. Per the [`os.CreateTemp` docs](https://pkg.go.dev/os#CreateTemp), cleanup is the caller's responsibility; `scanModule` now defers `os.Remove(profile)` once `runTests` succeeds.

Move coverage profile path from a local variable in scanner.go into the ModuleCoverage.Profile field so tests can directly verify cleanup with os.Stat + os.ErrNotExist instead of globbing /tmp for leaked temp files.

## Related issues

Closes #37 

## Checklist
- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Tests added for new functionality
- [ ] Documentation updated if needed