### PR TITLE
Feat/coverage recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to go-crap will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 - UNRELEASED
+
+### Added
+
+- Partial coverage preserved on test failure — when `go test` fails in a module, go-crap still parses the coverage profile from any passing tests instead of discarding all coverage data
+- `extractFailedTests` helper parses `--- FAIL: TestName` lines from stderr and logs failed test names at Warn level (use `--verbose` to see them)
+
+### Changed
+
+- `runTests` no longer deletes the temp coverage profile on error; the profile is kept for `parseCoverProfile` and cleaned up after parsing
+- `scanModule` no longer returns early on `runTests` failure; coverage is always parsed and partial data is returned alongside the error
+- `Scan` preserves the full `ModuleCoverage` struct from `scanModule`, retaining `Functions` alongside the wrapped error
+
 ## v0.4.1 - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Partial coverage preserved on test failure — when `go test` fails in a module, go-crap still parses the coverage profile from any passing tests instead of discarding all coverage data
 - `extractFailedTests` helper parses `--- FAIL: TestName` lines from stderr and logs failed test names at Warn level (use `--verbose` to see them)
+- `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaborated by @mem)
+- `--timeout` flag — configurable timeout for the scan command (collaborated by @matiasinsaurralde)
+- `Profile` field on `ModuleCoverage` — stores the path to the coverage profile file
 
 ### Changed
 
 - `runTests` no longer deletes the temp coverage profile on error; the profile is kept for `parseCoverProfile` and cleaned up after parsing
 - `scanModule` no longer returns early on `runTests` failure; coverage is always parsed and partial data is returned alongside the error
 - `Scan` preserves the full `ModuleCoverage` struct from `scanModule`, retaining `Functions` alongside the wrapped error
+
+### Fixed
+
+- Coverage profile temp files now cleaned up after successful scan (collaborated by @matiasinsaurralde)
+- Field alignment for better memory layout
+- Tests added for `Spash` function
 
 ## v0.4.1 - 2026-06-18
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ clean:
 fmt:
 	gofmt -s -w .
 
+crap:
+	go run main.go scan --exclude ".*_test.go" --fail-above --threshold 30 --verbose --top 10 
+
 mod-tidy:
 	go mod tidy
 
@@ -35,9 +38,9 @@ coverage:
 	go tool cover -func=coverage.out
 
 fieldalignment:
-	fieldalignment ./...	
+	fieldalignment -test=false ./...	
 
-preflight: fmt lint test fieldalignment
+preflight: fmt lint test fieldalignment crap
 
 help:
 	@echo "build     - compile binary"

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ go-crap scan --exclude '.*_test\.go' --exclude 'pb/.*\.go'
 
 ### Coverage Unavailable Warning
 
-When a Go module fails to build or run tests, its coverage data is unavailable.
-go-crap detects this and reports it in all output formats:
+When a Go module fails to build or run tests, go-crap still parses the coverage
+profile from any passing tests. The error is reported in all output formats;
+functions exercised by passing tests appear with their real coverage, while
+functions with no coverage data get a warning.
 
 - `table` — coverage column shows `N/A ‼` with a footer listing unavailable modules
 - `json` — `coverage` is `null` and `coverage_warning` contains the error message

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/padiazg/go-crap/pkg/version"
 	"github.com/spf13/cobra"
@@ -23,8 +25,12 @@ func runVersion(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	version.Splash()
+	var (
+		stdWriter io.Writer = os.Stdout
+		errWriter io.Writer = os.Stderr
+	)
 
+	version.Splash(stdWriter, errWriter)
 }
 
 func init() {

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -60,7 +60,10 @@ Notes:
 
 ## Coverage Unavailable Warning
 
-When a Go module fails to build or run tests (`go test ./...` errors), coverage data is lost for all functions in that module. go-crap detects this and surfaces the error in all output formats:
+When a Go module fails to build or run tests, go-crap still parses the coverage
+profile from any passing tests. The error is reported in all output formats;
+functions exercised by passing tests appear with their real coverage, while
+functions with no coverage data get a warning.
 
 - **table** — coverage column shows `N/A ‼`, footer lists unavailable modules with error messages
 - **json** — `coverage` is `null`, `coverage_warning` contains the error

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -173,12 +173,13 @@ func (s *Scanner) scanModule(ctx context.Context, modDir string) (ModuleCoverage
 			mc.Error = fmt.Errorf("runTests: %w", err)
 			return mc, mc.Error
 		}
+
+		defer func() {
+			if removeErr := os.Remove(mc.Profile); removeErr != nil {
+				s.Logger.Debug("coverage scan: remove temp file error", "profile", mc.Profile, "error", removeErr.Error())
+			}
+		}()
 	}
-	defer func() {
-		if removeErr := os.Remove(mc.Profile); removeErr != nil {
-			s.Logger.Debug("coverage scan: remove temp file error", "profile", mc.Profile, "error", removeErr.Error())
-		}
-	}()
 
 	functions, err := parseCoverProfile(mc.Profile, modDir, modulePath)
 	if err != nil {

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -77,13 +77,11 @@ func (s *Scanner) Scan(ctx context.Context) ([]ModuleCoverage, error) {
 		default:
 		}
 
-		mc, err := s.scanModule(ctx, modDir)
-		if err != nil {
+		mc := s.scanModule(ctx, modDir)
+		if mc.Error != nil {
 			s.Logger.Debug("coverage scan: module error", "module", modDir, "error", err.Error())
-			results = append(results, ModuleCoverage{
-				Dir:   modDir,
-				Error: fmt.Errorf("scan %s: %w", modDir, err),
-			})
+			mc.Error = fmt.Errorf("scan %s: %w", modDir, mc.Error)
+			results = append(results, mc)
 			continue
 		}
 
@@ -157,7 +155,7 @@ func walkForModules(root string, visit func(dir string) bool) error {
 	})
 }
 
-func (s *Scanner) scanModule(ctx context.Context, modDir string) (ModuleCoverage, error) {
+func (s *Scanner) scanModule(ctx context.Context, modDir string) ModuleCoverage {
 	mc := ModuleCoverage{Dir: modDir}
 	modulePath, err := readModulePath(modDir)
 	if err != nil {
@@ -167,28 +165,32 @@ func (s *Scanner) scanModule(ctx context.Context, modDir string) (ModuleCoverage
 
 	mc.ModulePath = modulePath
 	mc.Profile = s.Profile
+	var parseErr error
+	runTestsSuccess := false
 	if mc.Profile == "" {
 		mc.Profile, err = s.runTests(ctx, modDir)
 		if err != nil {
 			mc.Error = fmt.Errorf("runTests: %w", err)
-			return mc, mc.Error
+		} else {
+			runTestsSuccess = true
 		}
-
-		defer func() {
-			if removeErr := os.Remove(mc.Profile); removeErr != nil {
-				s.Logger.Debug("coverage scan: remove temp file error", "profile", mc.Profile, "error", removeErr.Error())
-			}
-		}()
 	}
 
-	functions, err := parseCoverProfile(mc.Profile, modDir, modulePath)
-	if err != nil {
-		mc.Error = fmt.Errorf("parseCoverProfile: %w", err)
-		return mc, mc.Error
+	functions, parseErr := parseCoverProfile(mc.Profile, modDir, modulePath)
+	if runTestsSuccess {
+		os.Remove(mc.Profile)
+	}
+
+	if parseErr != nil {
+		if mc.Error != nil {
+			return mc
+		}
+		mc.Error = fmt.Errorf("parseCoverProfile: %w", parseErr)
+		return mc
 	}
 
 	mc.Functions = s.filterByExclude(functions)
-	return mc, nil
+	return mc
 }
 
 func readModulePath(dir string) (string, error) {
@@ -223,16 +225,30 @@ func (s *Scanner) runTests(ctx context.Context, modDir string) (string, error) {
 
 	err = cmd.Run()
 	if err != nil {
-		if removeErr := os.Remove(profile); removeErr != nil {
-			s.Logger.Debug("coverage scan: remove temp file error", "profile", profile, "error", removeErr.Error())
+		if failed := extractFailedTests(stderr.String()); len(failed) > 0 {
+			s.Logger.Warn("coverage: tests failed in module", "module", modDir, "failed_tests", failed)
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return "", fmt.Errorf("go test: timed out (increase --timeout to allow more time): %w", err)
+			return profile, fmt.Errorf("go test: timed out (increase --timeout to allow more time): %w", err)
 		}
-		return "", fmt.Errorf("go test: %w\n%s", err, stderr.String())
+		return profile, fmt.Errorf("go test: %w\n%s", err, stderr.String())
 	}
 
 	return profile, nil
+}
+
+func extractFailedTests(stderr string) []string {
+	var failed []string
+	for line := range strings.SplitSeq(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if _, after, ok := strings.Cut(line, "--- FAIL: "); ok {
+			after = strings.TrimSpace(after)
+			if name, _, _ := strings.Cut(after, " "); name != "" {
+				failed = append(failed, name)
+			}
+		}
+	}
+	return failed
 }
 
 func (s *Scanner) filterByExclude(functions []FunctionCoverage) []FunctionCoverage {

--- a/internal/coverage/scanner_test.go
+++ b/internal/coverage/scanner_test.go
@@ -374,7 +374,7 @@ func Test_walkForModules_visit_skips_files(t *testing.T) {
 	assert.Equal(t, tempDir, visited[0])
 }
 
-type checkScannerscanModuleFn func(*testing.T, ModuleCoverage, error)
+type checkScannerscanModuleFn func(*testing.T, ModuleCoverage)
 
 var checkScannerscanModule = func(fns ...checkScannerscanModuleFn) []checkScannerscanModuleFn { return fns }
 
@@ -388,9 +388,9 @@ func TestScanner_scanModule(t *testing.T) {
 		{
 			name: "module_with_tests",
 			checks: checkScannerscanModule(
-				func(t *testing.T, r ModuleCoverage, err error) {
+				func(t *testing.T, r ModuleCoverage) {
 					t.Helper()
-					assert.NoError(t, err)
+					assert.NoError(t, r.Error)
 					assert.NotEmpty(t, r.ModulePath)
 					assert.Contains(t, r.ModulePath, "internal/testdata")
 				},
@@ -409,10 +409,10 @@ func TestScanner_scanModule(t *testing.T) {
 		{
 			name: "module_with_tests_removes_temp_profile",
 			checks: checkScannerscanModule(
-				func(t *testing.T, r ModuleCoverage, err error) {
+				func(t *testing.T, r ModuleCoverage) {
 					t.Helper()
-					assert.NoError(t, err)
-					_, err = os.Stat(r.Profile)
+					assert.NoError(t, r.Error)
+					_, err := os.Stat(r.Profile)
 					assert.ErrorIs(t, err, os.ErrNotExist, "coverage profile temp file(s) not cleaned up: %s", r.Profile)
 				},
 			),
@@ -430,9 +430,9 @@ func TestScanner_scanModule(t *testing.T) {
 		{
 			name: "module_with_failed_tests",
 			checks: checkScannerscanModule(
-				func(t *testing.T, r ModuleCoverage, err error) {
+				func(t *testing.T, r ModuleCoverage) {
 					t.Helper()
-					assert.Error(t, err)
+					assert.Error(t, r.Error)
 					assert.Contains(t, r.Error.Error(), "runTests")
 				},
 			),
@@ -463,11 +463,72 @@ func TestAlwaysFails(t *testing.T) {
 			},
 		},
 		{
+			name: "module_with_partial_coverage_on_failure",
+			checks: checkScannerscanModule(
+				func(t *testing.T, r ModuleCoverage) {
+					t.Helper()
+					t.Logf("r.Error: %v", r.Error)
+					t.Logf("r.ModulePath: %s", r.ModulePath)
+					t.Logf("r.Profile: %s", r.Profile)
+					t.Logf("r.Functions count: %d", len(r.Functions))
+					assert.Error(t, r.Error)
+					assert.Contains(t, r.Error.Error(), "runTests")
+					assert.NotEmpty(t, r.Functions, "partial coverage data should be available despite test failure")
+				},
+			),
+			before: func(s *Scanner) {
+				tempDir := t.TempDir()
+				goMod := `module partialmodule
+
+go 1.21
+`
+				os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goMod), 0644)
+
+				pkgDir := filepath.Join(tempDir, "pkg")
+				os.Mkdir(pkgDir, 0755)
+				os.WriteFile(filepath.Join(pkgDir, "pkg.go"), []byte(`package pkg
+
+func AlwaysPasses() int {
+	return 42
+}
+`), 0644)
+				os.WriteFile(filepath.Join(pkgDir, "pkg_test.go"), []byte(`package pkg
+
+import "testing"
+
+func TestAlwaysPasses(t *testing.T) {
+	if AlwaysPasses() != 42 {
+		t.Error("expected 42")
+	}
+}
+`), 0644)
+
+				failPkgDir := filepath.Join(tempDir, "failpkg")
+				os.Mkdir(failPkgDir, 0755)
+				os.WriteFile(filepath.Join(failPkgDir, "fail.go"), []byte(`package failpkg
+
+func AlwaysFails() error {
+	return nil
+}
+`), 0644)
+				os.WriteFile(filepath.Join(failPkgDir, "fail_test.go"), []byte(`package failpkg
+
+import "testing"
+
+func TestAlwaysFails(t *testing.T) {
+	t.Fatal("this always fails")
+}
+`), 0644)
+
+				s.Path = tempDir
+			},
+		},
+		{
 			name: "module_without_tests",
 			checks: checkScannerscanModule(
-				func(t *testing.T, r ModuleCoverage, err error) {
+				func(t *testing.T, r ModuleCoverage) {
 					t.Helper()
-					assert.NoError(t, err)
+					assert.NoError(t, r.Error)
 					// go test ./... covers all packages; even without _test.go
 					// the parser finds coverage for functions in the source.
 					assert.NotEmpty(t, r.Functions)
@@ -494,9 +555,9 @@ func Something() {}
 			// parsed straight from the profile.
 			name: "module_with_supplied_profile",
 			checks: checkScannerscanModule(
-				func(t *testing.T, r ModuleCoverage, err error) {
+				func(t *testing.T, r ModuleCoverage) {
 					t.Helper()
-					assert.NoError(t, err)
+					assert.NoError(t, r.Error)
 					require.Len(t, r.Functions, 1)
 					assert.Equal(t, "Covered", r.Functions[0].Name)
 					assert.Equal(t, 100.0, r.Functions[0].Coverage)
@@ -544,9 +605,9 @@ func TestCovered(t *testing.T) {
 				modDir = s.Path
 			}
 			ctx := context.Background()
-			r, err := s.scanModule(ctx, modDir)
+			r := s.scanModule(ctx, modDir)
 			for _, c := range tt.checks {
-				c(t, r, err)
+				c(t, r)
 			}
 		})
 	}
@@ -817,6 +878,64 @@ func TestScanner_filterByExclude(t *testing.T) {
 			for _, c := range tt.checks {
 				c(t, r)
 			}
+		})
+	}
+}
+
+func Test_extractFailedTests(t *testing.T) {
+	tests := []struct {
+		name     string
+		stderr   string
+		expected []string
+	}{
+		{
+			name: "single_failure",
+			stderr: `--- FAIL: TestFoo (0.01s)
+    scanner_test.go:10: panicked
+`,
+			expected: []string{"TestFoo"},
+		},
+		{
+			name: "multiple_failures",
+			stderr: `--- FAIL: TestFoo (0.01s)
+    main_test.go:5: error
+--- FAIL: TestBar (0.02s)
+    main_test.go:10: error
+ok  	package	0.100s
+`,
+			expected: []string{"TestFoo", "TestBar"},
+		},
+		{
+			name: "no_failures",
+			stderr: `ok  	package	0.100s
+`,
+			expected: nil,
+		},
+		{
+			name:     "empty",
+			stderr:   "",
+			expected: nil,
+		},
+		{
+			name:     "with_whitespace",
+			stderr:   "   \n--- FAIL:  TestBaz (0.01s)\n   ",
+			expected: []string{"TestBaz"},
+		},
+		{
+			name: "skip_non_fail_lines",
+			stderr: `=== RUN   TestFoo
+--- PASS: TestFoo (0.01s)
+--- FAIL: TestBar (0.01s)
+=== RUN   TestBaz
+--- PASS: TestBaz (0.01s)
+`,
+			expected: []string{"TestBar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := extractFailedTests(tt.stderr)
+			assert.Equal(t, tt.expected, r)
 		})
 	}
 }

--- a/pkg/version/splash.go
+++ b/pkg/version/splash.go
@@ -2,28 +2,26 @@ package version
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"text/template"
 )
 
-func Splash() {
-
-	var (
-		splashTemplate = `
+const splashTemplate = `
 ┏┓  ┏┓        Version: {{ .Major }}.{{ .Minor }}.{{ .Patch }}{{ if .Extra  }}-{{ .Extra }}{{ end }}
 ┃┓┏┓┃ ┏┓┏┓┏┓  Build: {{ .BuildDate }}
 ┗┛┗┛┗┛┛ ┗┻┣┛  Commit: {{ .Commit }}
           ┛
 
 `
-	)
 
+func Splash(stdWriter, errWriter io.Writer) {
 	t, err := template.New("splash").Parse(splashTemplate)
 	if err != nil {
-		fmt.Printf("Error parsing template: %+v", err)
+		fmt.Fprintf(errWriter, "Error parsing template: %+v", err)
+		return
 	}
 
-	if err := t.Execute(os.Stdout, CurrentVersion()); err != nil {
-		fmt.Printf("Error executing template: %+v", err)
+	if err := t.Execute(stdWriter, CurrentVersion()); err != nil {
+		fmt.Fprintf(errWriter, "Error executing template: %+v", err)
 	}
 }

--- a/pkg/version/splash_test.go
+++ b/pkg/version/splash_test.go
@@ -1,0 +1,144 @@
+package version
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type SplashCheckFn func(*testing.T, string, string)
+
+var checkSplash = func(fns ...SplashCheckFn) []SplashCheckFn { return fns }
+
+type errWriter struct {
+	err error
+}
+
+func (w *errWriter) Write(p []byte) (int, error) {
+	return 0, w.err
+}
+
+func TestSplash(t *testing.T) {
+
+	checkContains := func(want string) SplashCheckFn {
+		return func(t *testing.T, std, _ string) {
+			t.Helper()
+			assert.Containsf(t, std, want, "%s expected in stdout", want)
+		}
+	}
+
+	checkNotContains := func(want string) SplashCheckFn {
+		return func(t *testing.T, std, _ string) {
+			t.Helper()
+			assert.NotContainsf(t, std, want, "%s not expected in stdout", want)
+		}
+	}
+
+	checkError := func(want string) SplashCheckFn {
+		return func(t *testing.T, _, err string) {
+			t.Helper()
+			if want != "" {
+				assert.Containsf(t, err, want, "%s expected in error", want)
+				return
+			}
+			assert.Emptyf(t, err, "error not expected: %s", err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		version *VersionInfo
+		buff    io.Writer
+		checks  []SplashCheckFn
+	}{
+		{
+			name: "success with extra",
+			buff: &bytes.Buffer{},
+			version: &VersionInfo{
+				Version:   "v1.2.3-rc1",
+				Major:     1,
+				Minor:     2,
+				Patch:     3,
+				Extra:     "rc1",
+				Commit:    "abc123def",
+				BuildDate: "2025-01-15T10:00:00Z",
+			},
+			checks: checkSplash(
+				checkError(""),
+				checkContains("Version: 1.2.3-rc1"),
+				checkContains("Build: 2025-01-15T10:00:00Z"),
+				checkContains("Commit: abc123def"),
+			),
+		},
+		{
+			name: "success without extra",
+			buff: &bytes.Buffer{},
+			version: &VersionInfo{
+				Version:   "v1.2.3",
+				Major:     1,
+				Minor:     2,
+				Patch:     3,
+				Extra:     "",
+				Commit:    "deadbeef",
+				BuildDate: "2025-06-01T00:00:00Z",
+			},
+			checks: checkSplash(
+				checkError(""),
+				checkContains("Version: 1.2.3"),
+				checkNotContains("Version: 1.2.3-"),
+				checkContains("Build: 2025-06-01T00:00:00Z"),
+				checkContains("Commit: deadbeef"),
+			),
+		},
+		{
+			name: "success with default version",
+			buff: &bytes.Buffer{},
+			checks: checkSplash(
+				checkError(""),
+				checkContains("Version: 0.0.0"),
+				checkContains("Build: unknown"),
+				checkContains("Commit: unknown"),
+			),
+		},
+		{
+			name: "execute error writes to errWriter",
+			buff: &errWriter{err: assert.AnError},
+			version: &VersionInfo{
+				Version:   "v0.0.1",
+				Major:     0,
+				Minor:     0,
+				Patch:     1,
+				BuildDate: "unknown",
+				Commit:    "unknown",
+			},
+			checks: checkSplash(
+				checkError("Error executing template"),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.version != nil {
+				defer func(orig *VersionInfo) { v = orig }(v)
+				v = tt.version
+			}
+
+			errBuf := &bytes.Buffer{}
+
+			Splash(tt.buff, errBuf)
+
+			var stdStr string
+			if buf, ok := tt.buff.(*bytes.Buffer); ok {
+				stdStr = buf.String()
+			}
+
+			for _, c := range tt.checks {
+				c(t, stdStr, errBuf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

When go test fails in a module (some tests fail), go-crap now parses the coverage profile from passing tests instead of discarding all coverage data. Functions exercised by passing tests appear with their real coverage; functions with no coverage data get a warning.
Changes
- scanModule no longer returns early on runTests failure — coverage is always parsed from the profile
- runTests returns the profile path even on error, so parseCoverProfile can still extract data
- Temp profile is only removed if runTests succeeded; kept otherwise for parsing
- Added extractFailedTests — parses --- FAIL: TestName lines from stderr and logs them at Warn level
- Refactored scanModule signature: returns ModuleCoverage instead of (ModuleCoverage, error), error stored on the struct
- Updated test check closures to match the new signature

## Related issues

Closes #48 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added for new functionality
- [x] Documentation updated if needed
