### PR TITLE
Feat/combined average report

### DIFF
--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -8,6 +8,24 @@ permissions:
   contents: read
 
 jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.2'
+          cache: true
+      - name: Install go-crap
+        run: go install github.com/padiazg/go-crap@latest
+      - name: Generate baseline
+        run: go-crap scan --format json --output crap-current.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: crap-baseline
+          path: crap-current.json
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +44,8 @@ jobs:
 
   crap:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, baseline]
+    if: always() && needs.test.result == 'success'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -35,14 +54,36 @@ jobs:
       - name: build
         run: make build
 
+      - name: Download baseline
+        uses: actions/download-artifact@v8
+        with:
+          name: crap-baseline
+          path: baseline
+        continue-on-error: true
+
       - name: version
         run: ./go-crap version
 
       - name: score
-        run: ./go-crap scan --format github --fail-above --threshold 30 --exclude ".*_test.go" --verbose
+        run: |
+          if [ -f baseline/crap-current.json ]; then
+            ./go-crap scan --baseline baseline/crap-current.json --format github --fail-above --threshold 30 --exclude ".*_test.go" --verbose
+          else
+            ./go-crap scan --format github --fail-above --threshold 30 --exclude ".*_test.go" --verbose
+          fi
+
+      - name: check for regressions
+        if: github.event_name == 'pull_request' && hashFiles('baseline/crap-current.json') != ''
+        run: ./go-crap scan --baseline baseline/crap-current.json --fail-regression
 
       - name: generate pr comment
-        run: ./go-crap scan --format pr-comment --threshold 30 --exclude ".*_test.go" --output pr-comment.md
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ -f baseline/crap-current.json ]; then
+            ./go-crap scan --baseline baseline/crap-current.json --format pr-comment --threshold 30 --exclude ".*_test.go" --output pr-comment.md
+          else
+            ./go-crap scan --format pr-comment --threshold 30 --exclude ".*_test.go" --output pr-comment.md
+          fi
 
       - name: save pr number
         if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaborated by @mem)
 - `--timeout` flag — configurable timeout for the scan command (collaborated by @matiasinsaurralde)
 - `Profile` field on `ModuleCoverage` — stores the path to the coverage profile file
+- Baseline comparison engine — load previous JSON reports for delta analysis
+- New `--baseline <path>` flag — compare current CRAP against a previous report
+- New `--fail-regression` flag — exit code 1 when functions regressed vs baseline
+- New `--fail-regression-threshold <float>` flag (default `0.01`) — minimum delta to trigger
+- `Baseline` struct with `LoadBaseline()` — parses JSON reports into comparison-ready data
+- `AnnotateWithBaseline()` — sets `BaselineCRAP` on each CRAP entry for delta tracking
+- `ComputeSummaryWithBaseline()` — aggregate stats with baseline/compare deltas
+- `FindRegressions()` — exported regression detection for CLI use
+- `ErrRegression` sentinel error — distinct from threshold exceedance
+- `BaselineCRAP` field on `CRAPEntry` — stores previous report CRAP value (-1 = new function)
+- `Delta` field on `CRAPEntry` — CRAP delta from baseline
 
 ### Changed
 
 - `runTests` no longer deletes the temp coverage profile on error; the profile is kept for `parseCoverProfile` and cleaned up after parsing
 - `scanModule` no longer returns early on `runTests` failure; coverage is always parsed and partial data is returned alongside the error
 - `Scan` preserves the full `ModuleCoverage` struct from `scanModule`, retaining `Functions` alongside the wrapped error
+- JSON schema bumped to 1.1.0 — per-entry `baseline_crap`/`delta` fields, `summary` object with baseline/compare
+- PR comment formatter: header shows Combined/Average CRAP with deltas vs baseline; ASCII badges (`[OK]`, `[!!]`, `[ERROR]`, `[NEW]`); "New Functions" and "Regressions" sections; summary table
+- Table formatter: `Δ` column when baseline available; per-function delta with `+X ↑` / `-X ↓`; delta footer lines
+- GitHub formatter: summary `::notice::` annotation when baseline provided
+- CLI: `--fail-regression` without `--baseline` returns error
+- JSON output: schema field updated to 1.1.0, new `summary` object with baseline/compare stats
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ go-crap scan --exclude '.*_test\.go' --exclude 'pb/.*\.go'
 | `--mutation-report` | | Path to gremlins JSON mutation report to validate coverage reliability | `""` |
 | `--detailed` | | Include mutation failure details (original code, replacement, line) in report output | `false` |
 | `--timeout` | | Timeout for the full scan (e.g. `30s`, `5m`, `1h30m`) | `10m0s` |
+| `--coverage-profile` | | Supply an existing coverage profile instead of running `go test` | `""` |
+| `--baseline` | | Path to a previous JSON report for baseline comparison | `""` |
+| `--fail-regression` | | Exit code 1 when functions regressed vs baseline | `false` |
+| `--fail-regression-threshold` | | Minimum delta to consider regression | `0.01` |
 | `--help` | `-h` | Help for scan | — |
 
 ### Output Formats
@@ -123,6 +127,21 @@ go-crap scan --mutation-report gremlins-report.json --format json --detailed
 
 The `--detailed` flag includes full mutation failure details in the output: `type`, `line`, `original_code`, and `replacement_code` for each survived mutant. In `json` format, these appear as a `mutation_details` array per entry. In `sarif` and `pr-comment` formats, survived mutations with code snippets are appended to the warning messages.
 
+### Example: Baseline comparison
+
+```shell
+# Run a scan and save it as a baseline
+go-crap scan --format json > baseline.json
+
+# Compare against the baseline
+go-crap scan --baseline baseline.json --format table
+
+# Enforce regression thresholds in CI
+go-crap scan --baseline baseline.json --fail-regression --fail-regression-threshold 0.01
+```
+
+When a baseline is provided, every formatter shows deltas: the PR comment header displays combined/average CRAP with deltas, the table adds a `Δ` column, and JSON includes per-entry `baseline_crap` and `delta` fields.
+
 ## What is CRAP?
 
 CRAP = **C**yclomatic **R**eadability **A**nd **P**redictability. It measures how expensive a function is to test.
@@ -173,12 +192,14 @@ go-crap scan
 ```
 
 - `--fail-above` exits with code 1 when any function exceeds the threshold
+- `--fail-regression` exits with code 1 when functions regressed vs baseline
 - `--format github` emits `::warning` annotations that render as PR comments
 - `--format sarif` outputs SARIF 2.1.0 for integration with code scanning tools
 - `--format pr-comment` generates a markdown table for pull request comments
 - `--output -o` writes results to a file instead of stdout
 - `--mutation-report` validates coverage reliability against mutation testing results
 - `--detailed` includes mutation failure details (code, line, type) in report output
+- `--baseline` loads a previous JSON report for delta analysis
 - Coverage-unavailable warnings are emitted for modules where `go test` fails
 
 ### Badge

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # go-crap
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/padiazg/go-crap.svg)](https://pkg.go.dev/github.com/padiazg/go-crap)
-[![Go Report Card](https://goreportcard.com/badge/github.com/padiazg/go-crap)](https://goreportcard.com/report/github.com/padiazg/go-crap)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CRAP analysis](https://github.com/padiazg/go-crap/actions/workflows/crap.yml/badge.svg?branch=master)](https://github.com/padiazg/go-crap/actions/workflows/crap.yml)
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -16,22 +16,22 @@ import (
 )
 
 var (
-	flagThreshold                float64
-	flagFailAbove                bool
-	flagFormat                   string
-	flagTop                      int
-	flagMin                      float64
-	flagMissing                  string
-	flagExclude                  []string
-	flagVerbose                  bool
-	flagOutput                   string
-	flagMutation                 string
-	flagDetailed                 bool
-	flagTimeout                  time.Duration
-	flagCoverProf                string
-	flagBaseline                 string
-	flagFailRegression           bool
-	flagFailRegressionThreshold  float64
+	flagThreshold               float64
+	flagFailAbove               bool
+	flagFormat                  string
+	flagTop                     int
+	flagMin                     float64
+	flagMissing                 string
+	flagExclude                 []string
+	flagVerbose                 bool
+	flagOutput                  string
+	flagMutation                string
+	flagDetailed                bool
+	flagTimeout                 time.Duration
+	flagCoverProf               string
+	flagBaseline                string
+	flagFailRegression          bool
+	flagFailRegressionThreshold float64
 
 	scanCmd = &cobra.Command{
 		Use:   "scan [path]",
@@ -121,13 +121,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	err = output(entries, outputConfig{
-		path:       path,
-		writer:     cmd.OutOrStdout(),
-		output:     flagOutput,
-		format:     flagFormat,
-		threshold:  flagThreshold,
-		detailed:   flagDetailed,
-		baseline:   baseline,
+		path:      path,
+		writer:    cmd.OutOrStdout(),
+		output:    flagOutput,
+		format:    flagFormat,
+		threshold: flagThreshold,
+		detailed:  flagDetailed,
+		baseline:  baseline,
 	})
 	if err != nil {
 		return err
@@ -160,13 +160,13 @@ func fmtRegressionError(w io.Writer, regressions []score.CRAPEntry, baselineSumm
 }
 
 type outputConfig struct {
-	path       string
-	writer     io.Writer
-	output     string
-	format     string
-	threshold  float64
-	detailed   bool
-	baseline   *report.Baseline
+	writer    io.Writer
+	baseline  *report.Baseline
+	format    string
+	output    string
+	path      string
+	threshold float64
+	detailed  bool
 }
 
 func output(entries *scan.Entries, config outputConfig) error {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -9,26 +9,29 @@ import (
 
 	"github.com/padiazg/go-crap/internal/report"
 	"github.com/padiazg/go-crap/internal/scan"
+	"github.com/padiazg/go-crap/internal/score"
 	"github.com/padiazg/go-crap/pkg/logger"
 	"github.com/padiazg/go-crap/pkg/slogger"
 	"github.com/spf13/cobra"
 )
 
 var (
-	flagThreshold float64
-	flagFailAbove bool
-	flagFormat    string
-	flagTop       int
-	flagMin       float64
-	flagMissing   string
-	flagExclude   []string
-	flagVerbose   bool
-	flagOutput    string
-	flagMutation  string
-	flagDetailed  bool
-	flagTimeout   time.Duration
-	flagCoverProf string
-	flagBaseline  string
+	flagThreshold                float64
+	flagFailAbove                bool
+	flagFormat                   string
+	flagTop                      int
+	flagMin                      float64
+	flagMissing                  string
+	flagExclude                  []string
+	flagVerbose                  bool
+	flagOutput                   string
+	flagMutation                 string
+	flagDetailed                 bool
+	flagTimeout                  time.Duration
+	flagCoverProf                string
+	flagBaseline                 string
+	flagFailRegression           bool
+	flagFailRegressionThreshold  float64
 
 	scanCmd = &cobra.Command{
 		Use:   "scan [path]",
@@ -67,6 +70,10 @@ func init() {
 		`Use an existing coverage profile (as produced by "go test -coverprofile") instead of running go test`)
 	scanCmd.Flags().StringVar(&flagBaseline, "baseline", "",
 		"Path to a previous JSON report to use as baseline for comparison")
+	scanCmd.Flags().BoolVar(&flagFailRegression, "fail-regression", false,
+		"Exit with code 1 if any function's CRAP score regressed compared to baseline")
+	scanCmd.Flags().Float64Var(&flagFailRegressionThreshold, "fail-regression-threshold", 0.01,
+		"Minimum delta to consider a regression when comparing against baseline")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -74,6 +81,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 	path := "."
 	if len(args) > 0 {
 		path = args[0]
+	}
+
+	if flagFailRegression && flagBaseline == "" {
+		return fmt.Errorf("--fail-regression requires --baseline")
 	}
 
 	logLevel := "error"
@@ -126,7 +137,26 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return scan.ErrThresholdExceeded
 	}
 
+	if flagFailRegression && baseline != nil {
+		regressions := report.FindRegressions(entries.List, flagFailRegressionThreshold)
+		if len(regressions) > 0 {
+			return fmtRegressionError(cmd.OutOrStderr(), regressions, baseline.Summary)
+		}
+	}
+
 	return nil
+}
+
+func fmtRegressionError(w io.Writer, regressions []score.CRAPEntry, baselineSummary report.Summary) error {
+	fmt.Fprintln(w, "CRAP regression detected:")
+	for _, e := range regressions {
+		fmt.Fprintf(w, "  %s:%d %s: %.2f -> %.2f (+%.2f)\n",
+			e.File, e.Line, e.FuncName,
+			e.BaselineCRAP, e.EffectiveCRAP,
+			e.EffectiveCRAP-e.BaselineCRAP)
+	}
+	fmt.Fprintf(w, "Combined CRAP: %+0.2f vs baseline\n", baselineSummary.Combined)
+	return scan.ErrRegression
 }
 
 type outputConfig struct {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -28,6 +28,7 @@ var (
 	flagDetailed  bool
 	flagTimeout   time.Duration
 	flagCoverProf string
+	flagBaseline  string
 
 	scanCmd = &cobra.Command{
 		Use:   "scan [path]",
@@ -64,6 +65,8 @@ func init() {
 		"Timeout for the full scan (e.g. 30s, 5m, 1h30m)")
 	scanCmd.Flags().StringVar(&flagCoverProf, "coverage-profile", "",
 		`Use an existing coverage profile (as produced by "go test -coverprofile") instead of running go test`)
+	scanCmd.Flags().StringVar(&flagBaseline, "baseline", "",
+		"Path to a previous JSON report to use as baseline for comparison")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -98,13 +101,22 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	var baseline *report.Baseline
+	if flagBaseline != "" {
+		baseline, err = report.LoadBaseline(flagBaseline)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = output(entries, outputConfig{
-		path:      path,
-		writer:    cmd.OutOrStdout(),
-		output:    flagOutput,
-		format:    flagFormat,
-		threshold: flagThreshold,
-		detailed:  flagDetailed,
+		path:       path,
+		writer:     cmd.OutOrStdout(),
+		output:     flagOutput,
+		format:     flagFormat,
+		threshold:  flagThreshold,
+		detailed:   flagDetailed,
+		baseline:   baseline,
 	})
 	if err != nil {
 		return err
@@ -118,12 +130,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 }
 
 type outputConfig struct {
-	path      string
-	writer    io.Writer
-	output    string
-	format    string
-	threshold float64
-	detailed  bool
+	path       string
+	writer     io.Writer
+	output     string
+	format     string
+	threshold  float64
+	detailed   bool
+	baseline   *report.Baseline
 }
 
 func output(entries *scan.Entries, config outputConfig) error {
@@ -138,6 +151,16 @@ func output(entries *scan.Entries, config outputConfig) error {
 		config.writer = f
 	}
 
+	var summary report.Summary
+	var baselineSummary *report.Baseline
+	if config.baseline != nil {
+		entries.List = report.AnnotateWithBaseline(entries.List, config.baseline)
+		summary = report.ComputeSummaryWithBaseline(entries, config.threshold, config.baseline)
+		baselineSummary = config.baseline
+	} else {
+		summary = report.ComputeSummary(entries, config.threshold)
+	}
+
 	formatter, err := resolveFormatter(config.format)
 	if err != nil {
 		return err
@@ -148,6 +171,8 @@ func output(entries *scan.Entries, config outputConfig) error {
 		Writer:    config.writer,
 		BaseDir:   config.path,
 		Detailed:  config.detailed,
+		Summary:   &summary,
+		Baseline:  baselineSummary,
 	}
 
 	if err := formatter.Format(entries, opts); err != nil {

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -186,6 +186,9 @@ func resetFlags() {
 	flagMutation = ""
 	flagDetailed = false
 	flagTimeout = 10 * time.Minute
+	flagBaseline = ""
+	flagFailRegression = false
+	flagFailRegressionThreshold = 0.01
 }
 
 func Test_timeoutFlag_registered(t *testing.T) {
@@ -264,6 +267,14 @@ func Test_runScan(t *testing.T) {
 			setup: func() { resetFlags(); flagTimeout = 2 * time.Minute },
 			checks: checkrunScan(
 				checkrunScanError(""),
+			),
+		},
+		{
+			name:  "fail-regression without baseline returns error",
+			args:  []string{"../internal/testdata"},
+			setup: func() { resetFlags(); flagFailRegression = true },
+			checks: checkrunScan(
+				checkrunScanError("--fail-regression requires --baseline"),
 			),
 		},
 	}

--- a/doc/docs/changelog.md
+++ b/doc/docs/changelog.md
@@ -5,6 +5,45 @@ All notable changes to go-crap will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 - UNRELEASED
+
+### Added
+
+- Partial coverage preserved on test failure — when `go test` fails in a module, go-crap still parses the coverage profile from any passing tests instead of discarding all coverage data
+- `extractFailedTests` helper parses `--- FAIL: TestName` lines from stderr and logs failed test names at Warn level (use `--verbose` to see them)
+- `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaborated by @mem)
+- `--timeout` flag — configurable timeout for the scan command (collaborated by @matiasinsaurralde)
+- `Profile` field on `ModuleCoverage` — stores the path to the coverage profile file
+- Baseline comparison engine — load previous JSON reports for delta analysis
+- New `--baseline <path>` flag — compare current CRAP against a previous report
+- New `--fail-regression` flag — exit code 1 when functions regressed vs baseline
+- New `--fail-regression-threshold <float>` flag (default `0.01`) — minimum delta to trigger
+- `Baseline` struct with `LoadBaseline()` — parses JSON reports into comparison-ready data
+- `AnnotateWithBaseline()` — sets `BaselineCRAP` on each CRAP entry for delta tracking
+- `ComputeSummaryWithBaseline()` — aggregate stats with baseline/compare deltas
+- `FindRegressions()` — exported regression detection for CLI use
+- `ErrRegression` sentinel error — distinct from threshold exceedance
+- `BaselineCRAP` field on `CRAPEntry` — stores previous report CRAP value (-1 = new function)
+- `Delta` field on `CRAPEntry` — CRAP delta from baseline
+
+### Changed
+
+- `runTests` no longer deletes the temp coverage profile on error; the profile is kept for `parseCoverProfile` and cleaned up after parsing
+- `scanModule` no longer returns early on `runTests` failure; coverage is always parsed and partial data is returned alongside the error
+- `Scan` preserves the full `ModuleCoverage` struct from `scanModule`, retaining `Functions` alongside the wrapped error
+- JSON schema bumped to 1.1.0 — per-entry `baseline_crap`/`delta` fields, `summary` object with baseline/compare
+- PR comment formatter: header shows Combined/Average CRAP with deltas vs baseline; ASCII badges (`[OK]`, `[!!]`, `[ERROR]`, `[NEW]`); "New Functions" and "Regressions" sections; summary table
+- Table formatter: `Δ` column when baseline available; per-function delta with `+X ↑` / `-X ↓`; delta footer lines
+- GitHub formatter: summary `::notice::` annotation when baseline provided
+- CLI: `--fail-regression` without `--baseline` returns error
+- JSON output: schema field updated to 1.1.0, new `summary` object with baseline/compare stats
+
+### Fixed
+
+- Coverage profile temp files now cleaned up after successful scan (collaborated by @matiasinsaurralde)
+- Field alignment for better memory layout
+- Tests added for `Spash` function
+
 ## v0.4.1 - 2026-06-18
 
 ### Added

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -31,6 +31,9 @@ go-crap scan [path] [flags]
 | `--mutation-report` | | Path to gremlins JSON mutation report to validate coverage reliability | `""` (disabled) |
 | `--detailed` | | Include mutation failure details (original/replacement code, line, type) in report output | `false` |
 | `--timeout` | | Timeout for the full scan (e.g. `30s`, `5m`, `1h30m`) | `10m0s` |
+| `--baseline` | | Path to a previous JSON report for baseline comparison | `""` |
+| `--fail-regression` | | Exit code 1 when functions regressed vs baseline | `false` |
+| `--fail-regression-threshold` | | Minimum delta to consider regression | `0.01` |
 
 > `CoverageUntrusted` has meaning only if `--mutation-report` was used.
 
@@ -190,3 +193,41 @@ The `--detailed` flag includes full mutation failure details in the report outpu
 - **Table**: no change — still shows ⚠ for untrusted coverage
 
 This is useful for debugging which specific mutants survived and what code transformations they represented.
+
+### Baseline comparison
+
+```shell
+go-crap scan --baseline baseline.json
+```
+
+Compare the current scan against a previous JSON report. Every formatter shows deltas:
+
+- **pr-comment**: header shows Combined/Average CRAP with deltas vs baseline, plus "New Functions" and "Regressions" sections
+- **table**: `Δ` column with per-function delta (e.g. `+15 ↑`), delta footer lines
+- **json**: per-entry `baseline_crap` and `delta` fields, `summary` object with baseline/compare stats
+- **github**: summary `::notice::` annotation when baseline provided
+
+### Regression enforcement
+
+```shell
+go-crap scan --baseline baseline.json --fail-regression
+```
+
+Exits with code 1 when any function's CRAP score has increased (regressed) compared to the baseline. Use `--fail-regression-threshold` to adjust the minimum delta that counts as a regression.
+
+### Combined threshold + regression
+
+```shell
+go-crap scan --fail-above --threshold 30 --baseline baseline.json --fail-regression
+```
+
+Fails if any function exceeds the threshold OR has regressed compared to baseline.
+
+### Creating a baseline
+
+```shell
+go-crap scan --format json > baseline.json
+go-crap scan --baseline baseline.json
+```
+
+Generate a JSON report to use as a baseline. Subsequent scans can compare against it to track quality over time.

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -45,6 +45,20 @@ The `--detailed` flag includes full mutation failure details in report output. E
 - **SARIF**: survived mutations with code diffs appended to warning messages
 - **PR Comment**: `Survived Mutants` column with inline code snippets
 
+### Baseline Comparison
+
+The `--baseline` flag loads a previous JSON report and compares the current scan against it. This lets you track quality over time and catch regressions in CI.
+
+When a baseline is provided:
+- **pr-comment**: header shows Combined/Average CRAP with deltas vs baseline, plus "New Functions" and "Regressions" sections
+- **table**: `Δ` column with per-function delta, delta footer lines
+- **json**: per-entry `baseline_crap` and `delta` fields, `summary` object with baseline/compare stats (schema 1.1.0)
+- **github**: summary `::notice::` annotation
+
+Use `--fail-regression` to exit with code 1 when functions have regressed compared to the baseline. Adjust sensitivity with `--fail-regression-threshold`.
+
+→ [Baseline Comparison Guide](integrations/baseline-comparison.md)
+
 ### Missing Coverage Policy
 
 When a function has no coverage data, go-crap can handle it three ways:

--- a/doc/docs/integrations/baseline-comparison.md
+++ b/doc/docs/integrations/baseline-comparison.md
@@ -1,0 +1,137 @@
+# Baseline Comparison
+
+Compare current CRAP scores against a previous report to detect regressions.
+
+## Quick Start
+
+Generate a baseline report, then compare future scans against it:
+
+```bash
+# Generate baseline
+go-crap scan --format json --output baseline.json
+
+# Compare against baseline
+go-crap scan --baseline baseline.json --format pr-comment
+```
+
+## CLI Flags
+
+### `--baseline <path>`
+
+Path to a previous JSON report for comparison.
+
+```bash
+go-crap scan --baseline previous-report.json
+```
+
+When set, each formatter includes delta information:
+
+- **Table**: `Δ` column showing per-function CRAP change
+- **PR Comment**: header with deltas, Regressions section, New Functions section
+- **JSON**: `baseline_crap`, `delta`, and `summary` object with baseline/compare fields
+- **GitHub**: summary `::notice::` annotation
+
+### `--fail-regression`
+
+Exit with code 1 if any function's CRAP score regressed compared to baseline.
+
+```bash
+go-crap scan --baseline baseline.json --fail-regression
+```
+
+Requires `--baseline`. Combines with `--fail-above` -- either check triggers exit code 1.
+
+### `--fail-regression-threshold <float>`
+
+Minimum CRAP delta to consider a regression (default: `0.01`).
+
+```bash
+go-crap scan --baseline baseline.json --fail-regression --fail-regression-threshold 5.0
+```
+
+Only flags functions whose CRAP increased by more than the threshold.
+
+## CI Example: GitHub Actions
+
+### Generate baseline on main
+
+```yaml
+name: crap-baseline
+on:
+  push:
+    branches: [main, master]
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Generate baseline
+        run: go install github.com/padiazg/go-crap@latest
+      - name: Run go-crap
+        run: go-crap scan --format json --output crap-current.json
+      - name: Upload baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: crap-baseline
+          path: crap-current.json
+```
+
+### Compare on PR
+
+```yaml
+name: crap-pr
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Download baseline
+        uses: actions/download-artifact@v4
+        with:
+          name: crap-baseline
+          path: baseline
+      - name: Run go-crap
+        run: go install github.com/padiazg/go-crap@latest
+      - name: Check for regressions
+        run: go-crap scan --baseline baseline/crap-current.json --fail-regression
+      - name: Generate PR comment
+        run: go-crap scan --baseline baseline/crap-current.json --format pr-comment --output pr-comment.md
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comment = fs.readFileSync('pr-comment.md', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+```
+
+### Combined threshold + regression check
+
+```yaml
+      - name: Check CRAP quality
+        run: >-
+          go-crap scan
+          --fail-above --threshold 30
+          --baseline baseline/crap-current.json
+          --fail-regression
+          --fail-regression-threshold 5.0
+```
+
+This fails if any function exceeds threshold 30 **or** if any function regressed by more than 5.0 vs baseline.

--- a/doc/docs/integrations/github-actions.md
+++ b/doc/docs/integrations/github-actions.md
@@ -252,6 +252,60 @@ jobs:
 
 The `<!-- go-crap-report -->` marker (emitted by `--format pr-comment`) ensures the comment is updated in place on subsequent pushes instead of creating duplicates.
 
+## Baseline comparison with `--baseline`
+
+Compare PR CRAP scores against a baseline to detect regressions. See [Baseline Comparison](baseline-comparison.md) for full documentation.
+
+```yaml
+name: crap
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Install go-crap
+        run: go install github.com/padiazg/go-crap@latest
+      - name: Generate baseline
+        run: go-crap scan --format json --output crap-current.json
+      - name: Upload baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: crap-baseline
+          path: crap-current.json
+
+  pr-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: baseline
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Install go-crap
+        run: go install github.com/padiazg/go-crap@latest
+      - name: Download baseline
+        uses: actions/download-artifact@v4
+        with:
+          name: crap-baseline
+          path: baseline
+      - name: Check for regressions
+        run: go-crap scan --baseline baseline/crap-current.json --fail-regression
+      - name: Generate PR comment
+        run: go-crap scan --baseline baseline/crap-current.json --format pr-comment --output pr-comment.md
+```
+
 ### Example output
 
 Before fixing -- functions above the threshold with unreliable coverage from survived mutants:

--- a/doc/docs/integrations/index.md
+++ b/doc/docs/integrations/index.md
@@ -5,6 +5,7 @@ Integrate go-crap into your continuous integration pipeline to enforce CRAP scor
 ## Providers
 
 - [GitHub Actions](github-actions.md) -- threshold enforcement, PR annotations, matrix builds, SARIF code scanning, fork-safe PR comments with mutation testing
+- [Baseline Comparison](baseline-comparison.md) -- load previous reports, track deltas, enforce regression thresholds in CI
 - [Gitea](gitea.md) -- Gitea Actions with annotation support
 - [GitLab CI](gitlab.md) -- quality stage with JSON artifact
 - [Azure DevOps](azure-devops.md) -- pipeline with artifact upload
@@ -80,7 +81,7 @@ The JSON output follows this schema:
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "entries": [
     {
       "file": "internal/pkg/foo.go",

--- a/internal/report/baseline.go
+++ b/internal/report/baseline.go
@@ -136,3 +136,19 @@ func ComputeSummaryWithBaseline(entries *scan.Entries, threshold float64, baseli
 
 	return s
 }
+
+const defaultDeltaTolerance = 0.01
+
+// FindRegressions returns entries whose effective CRAP increased compared to baseline.
+func FindRegressions(entries []score.CRAPEntry, tolerance float64) []score.CRAPEntry {
+	if tolerance == 0 {
+		tolerance = defaultDeltaTolerance
+	}
+	result := make([]score.CRAPEntry, 0)
+	for _, e := range entries {
+		if e.BaselineCRAP >= 0 && e.EffectiveCRAP-e.BaselineCRAP > tolerance {
+			result = append(result, e)
+		}
+	}
+	return result
+}

--- a/internal/report/baseline.go
+++ b/internal/report/baseline.go
@@ -17,12 +17,12 @@ type Baseline struct {
 
 // BaselineEntry holds CRAP data for a single function from a baseline report.
 type BaselineEntry struct {
+	File          string
+	FuncName      string
 	CRAP          float64
-	EffectiveCRAP float64
 	Complexity    int
 	Coverage      float64
-	FuncName      string
-	File          string
+	EffectiveCRAP float64
 	Line          int
 }
 
@@ -34,9 +34,9 @@ func LoadBaseline(path string) (*Baseline, error) {
 	}
 
 	var report struct {
-		Schema  string       `json:"$schema"`
-		Version string       `json:"version"`
-		Entries []JSONEntry  `json:"entries"`
+		Schema  string      `json:"$schema"`
+		Version string      `json:"version"`
+		Entries []JSONEntry `json:"entries"`
 	}
 
 	if err := json.Unmarshal(data, &report); err != nil {

--- a/internal/report/baseline.go
+++ b/internal/report/baseline.go
@@ -1,0 +1,138 @@
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/padiazg/go-crap/internal/scan"
+	"github.com/padiazg/go-crap/internal/score"
+)
+
+// Baseline represents a previous go-crap JSON report used for comparison.
+type Baseline struct {
+	entries map[string]BaselineEntry
+	Summary Summary
+}
+
+// BaselineEntry holds CRAP data for a single function from a baseline report.
+type BaselineEntry struct {
+	CRAP          float64
+	EffectiveCRAP float64
+	Complexity    int
+	Coverage      float64
+	FuncName      string
+	File          string
+	Line          int
+}
+
+// LoadBaseline loads a baseline from a JSON report file.
+func LoadBaseline(path string) (*Baseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("baseline: %w", err)
+	}
+
+	var report struct {
+		Schema  string       `json:"$schema"`
+		Version string       `json:"version"`
+		Entries []JSONEntry  `json:"entries"`
+	}
+
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("baseline: invalid JSON: %w", err)
+	}
+
+	b := &Baseline{
+		entries: make(map[string]BaselineEntry),
+	}
+
+	for _, e := range report.Entries {
+		entry := BaselineEntry{
+			CRAP:          e.CRAP,
+			EffectiveCRAP: e.EffectiveCRAP,
+			Complexity:    e.Cyclomatic,
+			Coverage:      coverageOrDefault(e.Coverage),
+			FuncName:      e.Function,
+			File:          e.File,
+			Line:          e.Line,
+		}
+		key := entry.File + ":" + entry.FuncName
+		b.entries[key] = entry
+	}
+
+	b.Summary = b.computeSummary()
+
+	return b, nil
+}
+
+func coverageOrDefault(f *float64) float64 {
+	if f == nil {
+		return 0
+	}
+	return *f
+}
+
+func (b *Baseline) computeSummary() Summary {
+	var combined float64
+	for _, e := range b.entries {
+		combined += e.EffectiveCRAP
+	}
+	total := len(b.entries)
+	var avg float64
+	if total > 0 {
+		avg = combined / float64(total)
+	}
+	return Summary{
+		Combined:   combined,
+		Average:    avg,
+		TotalFuncs: total,
+	}
+}
+
+// Lookup returns the baseline entry for a given file:funcname key.
+func (b *Baseline) Lookup(file, funcname string) (BaselineEntry, bool) {
+	key := file + ":" + funcname
+	entry, ok := b.entries[key]
+	return entry, ok
+}
+
+// BaselineEntries returns all baseline entries for iteration.
+func (b *Baseline) BaselineEntries() []BaselineEntry {
+	result := make([]BaselineEntry, 0, len(b.entries))
+	for _, e := range b.entries {
+		result = append(result, e)
+	}
+	return result
+}
+
+// AnnotateWithBaseline sets BaselineCRAP on each entry based on the baseline.
+func AnnotateWithBaseline(entries []score.CRAPEntry, baseline *Baseline) []score.CRAPEntry {
+	if baseline == nil {
+		return entries
+	}
+	result := make([]score.CRAPEntry, len(entries))
+	for i, e := range entries {
+		result[i] = e
+		if bl, ok := baseline.Lookup(e.File, e.FuncName); ok {
+			result[i].BaselineCRAP = bl.EffectiveCRAP
+		} else {
+			result[i].BaselineCRAP = -1
+		}
+	}
+	return result
+}
+
+// ComputeSummaryWithBaseline computes aggregate CRAP stats and compares against baseline.
+func ComputeSummaryWithBaseline(entries *scan.Entries, threshold float64, baseline *Baseline) Summary {
+	s := ComputeSummary(entries, threshold)
+
+	if baseline != nil {
+		s.BaselineCombined = baseline.Summary.Combined
+		s.BaselineAverage = baseline.Summary.Average
+		s.DeltaCombined = s.Combined - baseline.Summary.Combined
+		s.DeltaAverage = s.Average - baseline.Summary.Average
+	}
+
+	return s
+}

--- a/internal/report/baseline_test.go
+++ b/internal/report/baseline_test.go
@@ -1,0 +1,886 @@
+package report
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/padiazg/go-crap/internal/scan"
+	"github.com/padiazg/go-crap/internal/score"
+)
+
+func TestLoadBaseline_valid_json(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "src/main.go",
+				"function": "ProcessData",
+				"line": 42,
+				"package": "myapp",
+				"cyclomatic": 5,
+				"coverage": 80.0,
+				"crap": 23.0,
+				"effective_crap": 23.0
+			},
+			{
+				"file": "src/utils.go",
+				"function": "HelperFunc",
+				"line": 10,
+				"package": "myapp",
+				"cyclomatic": 2,
+				"coverage": 100.0,
+				"crap": 2.0,
+				"effective_crap": 2.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	assert.NotNil(t, baseline)
+	assert.Len(t, baseline.entries, 2)
+
+	entry, ok := baseline.Lookup("src/main.go", "ProcessData")
+	assert.True(t, ok)
+	assert.Equal(t, "ProcessData", entry.FuncName)
+	assert.Equal(t, 23.0, entry.EffectiveCRAP)
+	assert.Equal(t, 23.0, entry.CRAP)
+	assert.Equal(t, 80.0, entry.Coverage)
+	assert.Equal(t, 5, entry.Complexity)
+	assert.Equal(t, 42, entry.Line)
+	assert.Equal(t, "src/main.go", entry.File)
+}
+
+func TestLoadBaseline_nonexistent_file(t *testing.T) {
+	_, err := LoadBaseline("/nonexistent/path/baseline.json")
+	assert.Error(t, err)
+}
+
+func TestLoadBaseline_invalid_json(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "invalid.json")
+
+	err := os.WriteFile(jsonPath, []byte("not valid json"), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadBaseline(jsonPath)
+	assert.Error(t, err)
+}
+
+func TestLoadBaseline_empty_entries(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "empty.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": []
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	assert.NotNil(t, baseline)
+	assert.Len(t, baseline.entries, 0)
+	assert.Equal(t, 0.0, baseline.Summary.Combined)
+	assert.Equal(t, 0.0, baseline.Summary.Average)
+}
+
+func TestLoadBaseline_null_coverage(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "null_cov.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "src/main.go",
+				"function": "NoCoverage",
+				"line": 1,
+				"package": "myapp",
+				"cyclomatic": 3,
+				"coverage": null,
+				"crap": 12.0,
+				"effective_crap": 12.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entry, ok := baseline.Lookup("src/main.go", "NoCoverage")
+	assert.True(t, ok)
+	assert.Equal(t, 0.0, entry.Coverage)
+	assert.Equal(t, 12.0, entry.EffectiveCRAP)
+}
+
+func TestBaselineLookup_not_found(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "src/main.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "myapp",
+				"cyclomatic": 3,
+				"coverage": 100.0,
+				"crap": 3.0,
+				"effective_crap": 3.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	_, ok := baseline.Lookup("src/main.go", "NonExistent")
+	assert.False(t, ok)
+
+	_, ok = baseline.Lookup("other/file.go", "FuncA")
+	assert.False(t, ok)
+}
+
+func TestBaseline_compute_summary(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "a.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "pkg",
+				"cyclomatic": 5,
+				"coverage": 100.0,
+				"crap": 5.0,
+				"effective_crap": 5.0
+			},
+			{
+				"file": "b.go",
+				"function": "FuncB",
+				"line": 10,
+				"package": "pkg",
+				"cyclomatic": 10,
+				"coverage": 0.0,
+				"crap": 110.0,
+				"effective_crap": 110.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	assert.InDelta(t, 115.0, baseline.Summary.Combined, 0.01)
+	assert.InDelta(t, 57.5, baseline.Summary.Average, 0.01)
+	assert.Equal(t, 2, baseline.Summary.TotalFuncs)
+}
+
+func TestAnnotateWithBaseline_matched_entries(t *testing.T) {
+	baseline := &Baseline{
+		entries: map[string]BaselineEntry{
+			"src/main.go:FuncA": {EffectiveCRAP: 50.0},
+			"src/main.go:FuncB": {EffectiveCRAP: 20.0},
+		},
+	}
+
+	entries := []score.CRAPEntry{
+		{File: "src/main.go", FuncName: "FuncA", CRAP: 60.0, EffectiveCRAP: 60.0},
+		{File: "src/main.go", FuncName: "FuncB", CRAP: 15.0, EffectiveCRAP: 15.0},
+	}
+
+	result := AnnotateWithBaseline(entries, baseline)
+
+	assert.Equal(t, 50.0, result[0].BaselineCRAP)
+	assert.Equal(t, 20.0, result[1].BaselineCRAP)
+}
+
+func TestAnnotateWithBaseline_unmatched_entries_new(t *testing.T) {
+	baseline := &Baseline{
+		entries: map[string]BaselineEntry{
+			"src/main.go:OldFunc": {EffectiveCRAP: 30.0},
+		},
+	}
+
+	entries := []score.CRAPEntry{
+		{File: "src/main.go", FuncName: "NewFunc", CRAP: 10.0, EffectiveCRAP: 10.0},
+	}
+
+	result := AnnotateWithBaseline(entries, baseline)
+
+	assert.Equal(t, -1.0, result[0].BaselineCRAP)
+}
+
+func TestAnnotateWithBaseline_nil_baseline(t *testing.T) {
+	entries := []score.CRAPEntry{
+		{File: "src/main.go", FuncName: "FuncA", CRAP: 10.0, EffectiveCRAP: 10.0},
+	}
+
+	result := AnnotateWithBaseline(entries, nil)
+
+	assert.Equal(t, 0.0, result[0].BaselineCRAP)
+	assert.Len(t, result, 1)
+}
+
+func TestAnnotateWithBaseline_multiple_mismatched(t *testing.T) {
+	baseline := &Baseline{
+		entries: map[string]BaselineEntry{
+			"src/a.go:FuncA": {EffectiveCRAP: 10.0},
+			"src/b.go:FuncB": {EffectiveCRAP: 20.0},
+			"src/c.go:FuncC": {EffectiveCRAP: 30.0},
+		},
+	}
+
+	entries := []score.CRAPEntry{
+		{File: "src/a.go", FuncName: "FuncA", CRAP: 10.0, EffectiveCRAP: 10.0},
+		{File: "src/b.go", FuncName: "FuncB", CRAP: 20.0, EffectiveCRAP: 20.0},
+		{File: "src/x.go", FuncName: "NewFunc", CRAP: 5.0, EffectiveCRAP: 5.0},
+		{File: "src/y.go", FuncName: "AnotherNew", CRAP: 8.0, EffectiveCRAP: 8.0},
+	}
+
+	result := AnnotateWithBaseline(entries, baseline)
+
+	assert.Equal(t, 10.0, result[0].BaselineCRAP)
+	assert.Equal(t, 20.0, result[1].BaselineCRAP)
+	assert.Equal(t, -1.0, result[2].BaselineCRAP)
+	assert.Equal(t, -1.0, result[3].BaselineCRAP)
+}
+
+func TestComputeSummaryWithBaseline_no_baseline(t *testing.T) {
+	entries := &scan.Entries{
+		List: []score.CRAPEntry{
+			{File: "a.go", FuncName: "A", CRAP: 10.0, EffectiveCRAP: 10.0},
+			{File: "b.go", FuncName: "B", CRAP: 20.0, EffectiveCRAP: 20.0},
+		},
+	}
+
+	summary := ComputeSummaryWithBaseline(entries, 15.0, nil)
+
+	assert.InDelta(t, 30.0, summary.Combined, 0.01)
+	assert.InDelta(t, 15.0, summary.Average, 0.01)
+	assert.Equal(t, 2, summary.TotalFuncs)
+	assert.Equal(t, 1, summary.Exceeded)
+	assert.Equal(t, 0.0, summary.BaselineCombined)
+	assert.Equal(t, 0.0, summary.BaselineAverage)
+	assert.Equal(t, 0.0, summary.DeltaCombined)
+	assert.Equal(t, 0.0, summary.DeltaAverage)
+}
+
+func TestComputeSummaryWithBaseline_with_baseline(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "a.go",
+				"function": "A",
+				"line": 1,
+				"package": "pkg",
+				"cyclomatic": 4,
+				"coverage": 100.0,
+				"crap": 4.0,
+				"effective_crap": 8.0
+			},
+			{
+				"file": "b.go",
+				"function": "B",
+				"line": 10,
+				"package": "pkg",
+				"cyclomatic": 10,
+				"coverage": 0.0,
+				"crap": 100.0,
+				"effective_crap": 18.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entries := &scan.Entries{
+		List: []score.CRAPEntry{
+			{File: "a.go", FuncName: "A", CRAP: 12.0, EffectiveCRAP: 12.0},
+			{File: "b.go", FuncName: "B", CRAP: 18.0, EffectiveCRAP: 18.0},
+		},
+	}
+
+	summary := ComputeSummaryWithBaseline(entries, 15.0, baseline)
+
+	assert.InDelta(t, 30.0, summary.Combined, 0.01)
+	assert.InDelta(t, 15.0, summary.Average, 0.01)
+	assert.Equal(t, 2, summary.TotalFuncs)
+	assert.Equal(t, 1, summary.Exceeded)
+	assert.InDelta(t, 26.0, summary.BaselineCombined, 0.01)
+	assert.InDelta(t, 13.0, summary.BaselineAverage, 0.01)
+	assert.InDelta(t, 4.0, summary.DeltaCombined, 0.01)
+	assert.InDelta(t, 2.0, summary.DeltaAverage, 0.01)
+}
+
+func TestComputeSummaryWithBaseline_regression(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "main.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "main",
+				"cyclomatic": 2,
+				"coverage": 100.0,
+				"crap": 2.0,
+				"effective_crap": 5.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entries := &scan.Entries{
+		List: []score.CRAPEntry{
+			{File: "main.go", FuncName: "FuncA", CRAP: 50.0, EffectiveCRAP: 50.0},
+		},
+	}
+
+	summary := ComputeSummaryWithBaseline(entries, 30.0, baseline)
+
+	assert.InDelta(t, 50.0, summary.Combined, 0.01)
+	assert.InDelta(t, 45.0, summary.DeltaCombined, 0.01)
+	assert.True(t, summary.DeltaCombined > 0, "positive delta means regression")
+}
+
+func TestComputeSummaryWithBaseline_improvement(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "main.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "main",
+				"cyclomatic": 10,
+				"coverage": 0.0,
+				"crap": 100.0,
+				"effective_crap": 50.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entries := &scan.Entries{
+		List: []score.CRAPEntry{
+			{File: "main.go", FuncName: "FuncA", CRAP: 5.0, EffectiveCRAP: 5.0},
+		},
+	}
+
+	summary := ComputeSummaryWithBaseline(entries, 30.0, baseline)
+
+	assert.InDelta(t, 5.0, summary.Combined, 0.01)
+	assert.InDelta(t, -45.0, summary.DeltaCombined, 0.01)
+	assert.True(t, summary.DeltaCombined < 0, "negative delta means improvement")
+}
+
+func TestBaselineEntries(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "a.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "pkg",
+				"cyclomatic": 3,
+				"coverage": 100.0,
+				"crap": 3.0,
+				"effective_crap": 3.0
+			},
+			{
+				"file": "b.go",
+				"function": "FuncB",
+				"line": 2,
+				"package": "pkg",
+				"cyclomatic": 5,
+				"coverage": 50.0,
+				"crap": 25.0,
+				"effective_crap": 25.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entries := baseline.BaselineEntries()
+	assert.Len(t, entries, 2)
+
+	entryMap := make(map[string]BaselineEntry)
+	for _, e := range entries {
+		entryMap[e.FuncName] = e
+	}
+
+	assert.Contains(t, entryMap, "FuncA")
+	assert.Contains(t, entryMap, "FuncB")
+}
+
+func TestAnnotateWithBaseline_preserves_original_fields(t *testing.T) {
+	baseline := &Baseline{
+		entries: map[string]BaselineEntry{
+			"src/main.go:FuncA": {EffectiveCRAP: 10.0},
+		},
+	}
+
+	entries := []score.CRAPEntry{
+		{
+			File:              "src/main.go",
+			FuncName:          "FuncA",
+			Package:           "mypkg",
+			Receiver:          "MyRecv",
+			CRAP:              50.0,
+			EffectiveCRAP:     50.0,
+			Complexity:        10,
+			Coverage:          50.0,
+			Line:              42,
+			CoverageUntrusted: true,
+			Skipped:           false,
+		},
+	}
+
+	result := AnnotateWithBaseline(entries, baseline)
+
+	assert.Equal(t, "mypkg", result[0].Package)
+	assert.Equal(t, "MyRecv", result[0].Receiver)
+	assert.Equal(t, 50.0, result[0].CRAP)
+	assert.Equal(t, 50.0, result[0].EffectiveCRAP)
+	assert.Equal(t, 10.0, result[0].BaselineCRAP)
+	assert.Equal(t, 10, result[0].Complexity)
+	assert.Equal(t, 50.0, result[0].Coverage)
+	assert.Equal(t, 42, result[0].Line)
+	assert.Equal(t, true, result[0].CoverageUntrusted)
+	assert.Equal(t, false, result[0].Skipped)
+}
+
+func TestLoadBaseline_json_envelope_shape(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "src/main.go",
+				"function": "Main",
+				"line": 1,
+				"package": "main",
+				"cyclomatic": 1,
+				"coverage": 100.0,
+				"crap": 1.0,
+				"effective_crap": 1.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Main", baseline.entries["src/main.go:Main"].FuncName)
+	assert.Equal(t, "src/main.go", baseline.entries["src/main.go:Main"].File)
+}
+
+func TestBaseline_empty_baseline_entries_map(t *testing.T) {
+	b := &Baseline{
+		entries: make(map[string]BaselineEntry),
+	}
+
+	_, ok := b.Lookup("any.go", "AnyFunc")
+	assert.False(t, ok)
+
+	assert.Len(t, b.BaselineEntries(), 0)
+
+	entries := []score.CRAPEntry{
+		{File: "any.go", FuncName: "AnyFunc", CRAP: 5.0, EffectiveCRAP: 5.0},
+	}
+
+	result := AnnotateWithBaseline(entries, b)
+	assert.Equal(t, -1.0, result[0].BaselineCRAP)
+}
+
+func TestComputeSummaryWithBaseline_empty_entries_with_baseline(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "a.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "pkg",
+				"cyclomatic": 3,
+				"coverage": 100.0,
+				"crap": 3.0,
+				"effective_crap": 3.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entries := &scan.Entries{List: []score.CRAPEntry{}}
+
+	summary := ComputeSummaryWithBaseline(entries, 30.0, baseline)
+
+	assert.Equal(t, 0.0, summary.Combined)
+	assert.Equal(t, 0.0, summary.Average)
+	assert.Equal(t, 0, summary.TotalFuncs)
+	assert.Equal(t, 0, summary.Exceeded)
+	assert.InDelta(t, 3.0, summary.BaselineCombined, 0.01)
+	assert.InDelta(t, -3.0, summary.DeltaCombined, 0.01)
+}
+
+func TestBaseline_entry_key_format(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "src/pkg/file.go",
+				"function": "FuncWithDots",
+				"line": 42,
+				"package": "pkg",
+				"cyclomatic": 3,
+				"coverage": 100.0,
+				"crap": 3.0,
+				"effective_crap": 3.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	_, ok := baseline.Lookup("src/pkg/file.go", "FuncWithDots")
+	assert.True(t, ok)
+
+	_, ok = baseline.Lookup("src/pkg/file.go:FuncWithDots", "")
+	assert.False(t, ok)
+}
+
+func TestBaseline_multiple_functions_same_file(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "main.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "main",
+				"cyclomatic": 2,
+				"coverage": 100.0,
+				"crap": 2.0,
+				"effective_crap": 2.0
+			},
+			{
+				"file": "main.go",
+				"function": "FuncB",
+				"line": 10,
+				"package": "main",
+				"cyclomatic": 4,
+				"coverage": 50.0,
+				"crap": 18.0,
+				"effective_crap": 18.0
+			},
+			{
+				"file": "main.go",
+				"function": "FuncC",
+				"line": 20,
+				"package": "main",
+				"cyclomatic": 6,
+				"coverage": 0.0,
+				"crap": 42.0,
+				"effective_crap": 42.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2.0, baseline.entries["main.go:FuncA"].EffectiveCRAP)
+	assert.Equal(t, 18.0, baseline.entries["main.go:FuncB"].EffectiveCRAP)
+	assert.Equal(t, 42.0, baseline.entries["main.go:FuncC"].EffectiveCRAP)
+
+	assert.InDelta(t, 62.0, baseline.Summary.Combined, 0.01)
+	assert.InDelta(t, 20.67, baseline.Summary.Average, 0.01)
+	assert.Equal(t, 3, baseline.Summary.TotalFuncs)
+}
+
+func TestBaseline_json_with_receiver(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "main.go",
+				"function": "MethodFunc",
+				"line": 10,
+				"package": "main",
+				"receiver": "MyType",
+				"cyclomatic": 3,
+				"coverage": 80.0,
+				"crap": 13.5,
+				"effective_crap": 13.5
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entry, ok := baseline.Lookup("main.go", "MethodFunc")
+	assert.True(t, ok)
+	assert.Equal(t, 13.5, entry.EffectiveCRAP)
+}
+
+func TestBaseline_json_with_mutation_details(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "main.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "main",
+				"cyclomatic": 3,
+				"coverage": 100.0,
+				"crap": 3.0,
+				"effective_crap": 3.0,
+				"mutation_score": 0.8
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	_, err = LoadBaseline(jsonPath)
+	assert.NoError(t, err)
+}
+
+func TestBaseline_roundtrip(t *testing.T) {
+	originalJSON := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "a.go",
+				"function": "Foo",
+				"line": 10,
+				"package": "pkg",
+				"receiver": "T",
+				"cyclomatic": 5,
+				"coverage": 80.0,
+				"crap": 23.0,
+				"effective_crap": 23.0,
+				"mutation_score": 0.7
+			}
+		]
+	}`
+
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+	err := os.WriteFile(jsonPath, []byte(originalJSON), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	entry, ok := baseline.Lookup("a.go", "Foo")
+	assert.True(t, ok)
+	assert.Equal(t, "Foo", entry.FuncName)
+	assert.Equal(t, "a.go", entry.File)
+	assert.Equal(t, 23.0, entry.CRAP)
+	assert.Equal(t, 23.0, entry.EffectiveCRAP)
+	assert.Equal(t, 5, entry.Complexity)
+	assert.Equal(t, 80.0, entry.Coverage)
+	assert.Equal(t, 10, entry.Line)
+}
+
+func BenchmarkLoadBaseline(b *testing.B) {
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "file.go",
+				"function": "FuncA",
+				"line": 1,
+				"package": "pkg",
+				"cyclomatic": 3,
+				"coverage": 100.0,
+				"crap": 3.0,
+				"effective_crap": 3.0
+			},
+			{
+				"file": "file.go",
+				"function": "FuncB",
+				"line": 10,
+				"package": "pkg",
+				"cyclomatic": 5,
+				"coverage": 50.0,
+				"crap": 25.0,
+				"effective_crap": 25.0
+			}
+		]
+	}`
+	dir := b.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = LoadBaseline(jsonPath)
+	}
+}
+
+func TestLoadBaseline_json_roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "baseline.json")
+
+	jsonData := `{
+		"$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+		"version": "1.0.0",
+		"entries": [
+			{
+				"file": "src/main.go",
+				"function": "ProcessData",
+				"line": 42,
+				"package": "myapp",
+				"cyclomatic": 5,
+				"coverage": 80.0,
+				"crap": 23.0,
+				"effective_crap": 23.0
+			},
+			{
+				"file": "src/utils.go",
+				"function": "HelperFunc",
+				"line": 10,
+				"package": "myapp",
+				"cyclomatic": 2,
+				"coverage": 100.0,
+				"crap": 2.0,
+				"effective_crap": 2.0
+			}
+		]
+	}`
+
+	err := os.WriteFile(jsonPath, []byte(jsonData), 0644)
+	require.NoError(t, err)
+
+	baseline, err := LoadBaseline(jsonPath)
+	require.NoError(t, err)
+
+	assert.Len(t, baseline.entries, 2)
+	assert.InDelta(t, 25.0, baseline.Summary.Combined, 0.01)
+	assert.InDelta(t, 12.5, baseline.Summary.Average, 0.01)
+
+	entry, ok := baseline.Lookup("src/main.go", "ProcessData")
+	assert.True(t, ok)
+	assert.Equal(t, 23.0, entry.EffectiveCRAP)
+}

--- a/internal/report/baseline_test.go
+++ b/internal/report/baseline_test.go
@@ -880,7 +880,56 @@ func TestLoadBaseline_json_roundtrip(t *testing.T) {
 	assert.InDelta(t, 25.0, baseline.Summary.Combined, 0.01)
 	assert.InDelta(t, 12.5, baseline.Summary.Average, 0.01)
 
-	entry, ok := baseline.Lookup("src/main.go", "ProcessData")
+entry, ok := baseline.Lookup("src/main.go", "ProcessData")
 	assert.True(t, ok)
-	assert.Equal(t, 23.0, entry.EffectiveCRAP)
+	assert.InDelta(t, 23.0, entry.EffectiveCRAP, 0.01)
+}
+
+func TestFindRegressions_empty(t *testing.T) {
+	entries := []score.CRAPEntry{
+		{File: "a.go", FuncName: "Foo", EffectiveCRAP: 10.0, BaselineCRAP: -1},
+	}
+	result := FindRegressions(entries, 0.01)
+	assert.Empty(t, result)
+}
+
+func TestFindRegressions_no_regresions(t *testing.T) {
+	entries := []score.CRAPEntry{
+		{File: "a.go", FuncName: "Foo", EffectiveCRAP: 10.0, BaselineCRAP: 15.0},
+		{File: "b.go", FuncName: "Bar", EffectiveCRAP: 5.0, BaselineCRAP: 8.0},
+	}
+	result := FindRegressions(entries, 0.01)
+	assert.Empty(t, result)
+}
+
+func TestFindRegressions_identifies_regresions(t *testing.T) {
+	entries := []score.CRAPEntry{
+		{File: "a.go", FuncName: "Foo", EffectiveCRAP: 15.0, BaselineCRAP: 10.0},
+		{File: "b.go", FuncName: "Bar", EffectiveCRAP: 5.0, BaselineCRAP: 8.0},
+		{File: "c.go", FuncName: "Baz", EffectiveCRAP: 20.0, BaselineCRAP: 18.0},
+	}
+	result := FindRegressions(entries, 0.01)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "Foo", result[0].FuncName)
+	assert.InDelta(t, 5.0, result[0].EffectiveCRAP-result[0].BaselineCRAP, 0.01)
+}
+
+func TestFindRegressions_tolerance_filters_small_deltas(t *testing.T) {
+	entries := []score.CRAPEntry{
+		{File: "a.go", FuncName: "Foo", EffectiveCRAP: 10.05, BaselineCRAP: 10.0},
+		{File: "b.go", FuncName: "Bar", EffectiveCRAP: 15.0, BaselineCRAP: 10.0},
+	}
+	result := FindRegressions(entries, 0.1)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Bar", result[0].FuncName)
+}
+
+func TestFindRegressions_default_tolerance(t *testing.T) {
+	entries := []score.CRAPEntry{
+		{File: "a.go", FuncName: "Foo", EffectiveCRAP: 10.02, BaselineCRAP: 10.0},
+		{File: "b.go", FuncName: "Bar", EffectiveCRAP: 10.005, BaselineCRAP: 10.0},
+	}
+	result := FindRegressions(entries, 0)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Foo", result[0].FuncName)
 }

--- a/internal/report/baseline_test.go
+++ b/internal/report/baseline_test.go
@@ -880,7 +880,7 @@ func TestLoadBaseline_json_roundtrip(t *testing.T) {
 	assert.InDelta(t, 25.0, baseline.Summary.Combined, 0.01)
 	assert.InDelta(t, 12.5, baseline.Summary.Average, 0.01)
 
-entry, ok := baseline.Lookup("src/main.go", "ProcessData")
+	entry, ok := baseline.Lookup("src/main.go", "ProcessData")
 	assert.True(t, ok)
 	assert.InDelta(t, 23.0, entry.EffectiveCRAP, 0.01)
 }

--- a/internal/report/github.go
+++ b/internal/report/github.go
@@ -33,6 +33,27 @@ func (f *GithubFormatter) Format(entries *scan.Entries, opts FormatOptions) erro
 			fmt.Fprintf(opts.Writer, "::warning file=%s,line=%d::%s\n", file, e.Line, msg)
 		}
 	}
+
+	if opts.Summary != nil && opts.Baseline != nil {
+		fmt.Fprintf(opts.Writer, "::notice::CRAP Summary: combined %.1f", opts.Summary.Combined)
+		if opts.Summary.DeltaCombined != 0 {
+			symbol := "+"
+			if opts.Summary.DeltaCombined < 0 {
+				symbol = ""
+			}
+			fmt.Fprintf(opts.Writer, "(%s%.1f vs baseline)", symbol, opts.Summary.DeltaCombined)
+		}
+		fmt.Fprintf(opts.Writer, ", average %.1f", opts.Summary.Average)
+		if opts.Summary.DeltaAverage != 0 {
+			symbol := "+"
+			if opts.Summary.DeltaAverage < 0 {
+				symbol = ""
+			}
+			fmt.Fprintf(opts.Writer, "(%s%.1f vs baseline)", symbol, opts.Summary.DeltaAverage)
+		}
+		fmt.Fprintf(opts.Writer, ", %d/%d functions exceed threshold\n", opts.Summary.Exceeded, opts.Summary.TotalFuncs)
+	}
+
 	return nil
 }
 

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -9,9 +9,11 @@ import (
 )
 
 type Report struct {
-	Schema  string      `json:"$schema"`
-	Version string      `json:"version"`
-	Entries []JSONEntry `json:"entries"`
+	Schema    string      `json:"$schema"`
+	Version   string      `json:"version"`
+	Combined  *float64    `json:"combined,omitempty"`
+	Average   *float64    `json:"average,omitempty"`
+	Entries   []JSONEntry `json:"entries"`
 }
 
 type JSONEntry struct {
@@ -60,6 +62,11 @@ func (f *JSONFormatter) Format(entries *scan.Entries, opts FormatOptions) error 
 		Schema:  "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
 		Version: "1.0.0",
 		Entries: make([]JSONEntry, 0, len(entries.List)),
+	}
+
+	if opts.Summary != nil {
+		report.Combined = &opts.Summary.Combined
+		report.Average = &opts.Summary.Average
 	}
 
 	for _, e := range entries.List {

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -9,25 +9,27 @@ import (
 )
 
 type Report struct {
-	Schema    string         `json:"$schema"`
-	Version   string         `json:"version"`
-	Summary   *SummaryObject `json:"summary,omitempty"`
-	Entries   []JSONEntry    `json:"entries"`
+	Schema  string         `json:"$schema"`
+	Version string         `json:"version"`
+	Summary *SummaryObject `json:"summary,omitempty"`
+	Entries []JSONEntry    `json:"entries"`
 }
 
 type SummaryObject struct {
-	Combined          float64 `json:"combined"`
-	Average           float64 `json:"average"`
-	TotalFuncs        int     `json:"total_funcs"`
-	Exceeded          int     `json:"exceeded"`
-	BaselineCombined  *float64 `json:"baseline_combined,omitempty"`
-	BaselineAverage   *float64 `json:"baseline_average,omitempty"`
-	DeltaCombined     *float64 `json:"delta_combined,omitempty"`
-	DeltaAverage      *float64 `json:"delta_average,omitempty"`
+	BaselineAverage  *float64 `json:"baseline_average,omitempty"`
+	BaselineCombined *float64 `json:"baseline_combined,omitempty"`
+	DeltaAverage     *float64 `json:"delta_average,omitempty"`
+	DeltaCombined    *float64 `json:"delta_combined,omitempty"`
+	Average          float64  `json:"average"`
+	Combined         float64  `json:"combined"`
+	Exceeded         int      `json:"exceeded"`
+	TotalFuncs       int      `json:"total_funcs"`
 }
 
 type JSONEntry struct {
+	BaselineCRAP      *float64             `json:"baseline_crap,omitempty"`
 	Coverage          *float64             `json:"coverage,omitempty"`
+	Delta             *float64             `json:"delta,omitempty"`
 	CoverageWarning   string               `json:"coverage_warning,omitempty"`
 	File              string               `json:"file"`
 	Function          string               `json:"function"`
@@ -37,8 +39,6 @@ type JSONEntry struct {
 	CRAP              float64              `json:"crap"`
 	Cyclomatic        int                  `json:"cyclomatic"`
 	EffectiveCRAP     float64              `json:"effective_crap"`
-	BaselineCRAP      *float64             `json:"baseline_crap,omitempty"`
-	Delta             *float64             `json:"delta,omitempty"`
 	Line              int                  `json:"line"`
 	MutationScore     float64              `json:"mutation_score"`
 	CoverageUntrusted bool                 `json:"coverage_untrusted"`

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -9,11 +9,21 @@ import (
 )
 
 type Report struct {
-	Schema    string      `json:"$schema"`
-	Version   string      `json:"version"`
-	Combined  *float64    `json:"combined,omitempty"`
-	Average   *float64    `json:"average,omitempty"`
-	Entries   []JSONEntry `json:"entries"`
+	Schema    string         `json:"$schema"`
+	Version   string         `json:"version"`
+	Summary   *SummaryObject `json:"summary,omitempty"`
+	Entries   []JSONEntry    `json:"entries"`
+}
+
+type SummaryObject struct {
+	Combined          float64 `json:"combined"`
+	Average           float64 `json:"average"`
+	TotalFuncs        int     `json:"total_funcs"`
+	Exceeded          int     `json:"exceeded"`
+	BaselineCombined  *float64 `json:"baseline_combined,omitempty"`
+	BaselineAverage   *float64 `json:"baseline_average,omitempty"`
+	DeltaCombined     *float64 `json:"delta_combined,omitempty"`
+	DeltaAverage      *float64 `json:"delta_average,omitempty"`
 }
 
 type JSONEntry struct {
@@ -27,6 +37,8 @@ type JSONEntry struct {
 	CRAP              float64              `json:"crap"`
 	Cyclomatic        int                  `json:"cyclomatic"`
 	EffectiveCRAP     float64              `json:"effective_crap"`
+	BaselineCRAP      *float64             `json:"baseline_crap,omitempty"`
+	Delta             *float64             `json:"delta,omitempty"`
 	Line              int                  `json:"line"`
 	MutationScore     float64              `json:"mutation_score"`
 	CoverageUntrusted bool                 `json:"coverage_untrusted"`
@@ -60,13 +72,23 @@ func (f *JSONFormatter) Format(entries *scan.Entries, opts FormatOptions) error 
 
 	report := Report{
 		Schema:  "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
-		Version: "1.0.0",
+		Version: "1.1.0",
 		Entries: make([]JSONEntry, 0, len(entries.List)),
 	}
 
 	if opts.Summary != nil {
-		report.Combined = &opts.Summary.Combined
-		report.Average = &opts.Summary.Average
+		report.Summary = &SummaryObject{
+			Combined:   opts.Summary.Combined,
+			Average:    opts.Summary.Average,
+			TotalFuncs: opts.Summary.TotalFuncs,
+			Exceeded:   opts.Summary.Exceeded,
+		}
+		if opts.Baseline != nil {
+			report.Summary.BaselineCombined = &opts.Summary.BaselineCombined
+			report.Summary.BaselineAverage = &opts.Summary.BaselineAverage
+			report.Summary.DeltaCombined = &opts.Summary.DeltaCombined
+			report.Summary.DeltaAverage = &opts.Summary.DeltaAverage
+		}
 	}
 
 	for _, e := range entries.List {
@@ -102,6 +124,13 @@ func (f *JSONFormatter) convertToJSONEntry(e score.CRAPEntry, opts FormatOptions
 		MutationScore:     e.MutationScore,
 		CoverageUntrusted: e.CoverageUntrusted,
 		CoverageWarning:   e.CoverageWarning,
+	}
+
+	if e.BaselineCRAP >= 0 {
+		baselineCRAP := e.BaselineCRAP
+		entry.BaselineCRAP = &baselineCRAP
+		delta := e.EffectiveCRAP - e.BaselineCRAP
+		entry.Delta = &delta
 	}
 
 	if opts.Detailed && len(e.MutationDetails) > 0 {

--- a/internal/report/json_test.go
+++ b/internal/report/json_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/padiazg/go-crap/internal/scan"
 	"github.com/padiazg/go-crap/internal/score"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type checkJSONFormatterFormatFn func(*testing.T, error)
@@ -660,3 +661,75 @@ func TestJSONFormatter_convertToJSONEntry_emptyMutationDetails_Nil(t *testing.T)
 // 	assert.Equal(t, "GoodFunction", goodEntry.Function)
 // 	assert.Nil(t, goodEntry.MutationDetails)
 // }
+
+func TestJSONFormatter_Format_summary_nil_backward_compat(t *testing.T) {
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "Foo", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+	}}
+	var gotReport Report
+	buf := &bytes.Buffer{}
+	opts := FormatOptions{Writer: buf, Summary: nil}
+	s := &JSONFormatter{}
+	captured := func(v any, prefix, indent string) ([]byte, error) {
+		data, err := json.MarshalIndent(v, prefix, indent)
+		if err == nil {
+			_ = json.Unmarshal(data, &gotReport)
+		}
+		return data, err
+	}
+	s.jsonMarshalIndent = captured
+	err := s.Format(entries, opts)
+	require.NoError(t, err)
+	assert.Nil(t, gotReport.Combined)
+	assert.Nil(t, gotReport.Average)
+}
+
+func TestJSONFormatter_Format_summary_non_nil(t *testing.T) {
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "Foo", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+		{File: "/project/main.go", Package: "myapp", FuncName: "Bar", Line: 10, Complexity: 10, Coverage: 0, CRAP: 100},
+	}}
+	combined := 101.0
+	average := 50.5
+	var gotReport Report
+	buf := &bytes.Buffer{}
+	opts := FormatOptions{Writer: buf, Summary: &Summary{Combined: combined, Average: average, TotalFuncs: 2, Exceeded: 1}}
+	s := &JSONFormatter{}
+	captured := func(v any, prefix, indent string) ([]byte, error) {
+		data, err := json.MarshalIndent(v, prefix, indent)
+		if err == nil {
+			_ = json.Unmarshal(data, &gotReport)
+		}
+		return data, err
+	}
+	s.jsonMarshalIndent = captured
+	err := s.Format(entries, opts)
+	require.NoError(t, err)
+	require.NotNil(t, gotReport.Combined)
+	require.NotNil(t, gotReport.Average)
+	assert.InDelta(t, combined, *gotReport.Combined, 0.01)
+	assert.InDelta(t, average, *gotReport.Average, 0.01)
+}
+
+func TestJSONFormatter_Format_summary_with_entries(t *testing.T) {
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "Foo", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+	}}
+	var gotReport Report
+	buf := &bytes.Buffer{}
+	opts := FormatOptions{Writer: buf, Summary: &Summary{Combined: 1.0, Average: 1.0, TotalFuncs: 1, Exceeded: 0}}
+	s := &JSONFormatter{}
+	captured := func(v any, prefix, indent string) ([]byte, error) {
+		data, err := json.MarshalIndent(v, prefix, indent)
+		if err == nil {
+			_ = json.Unmarshal(data, &gotReport)
+		}
+		return data, err
+	}
+	s.jsonMarshalIndent = captured
+	err := s.Format(entries, opts)
+	require.NoError(t, err)
+	assert.NotNil(t, gotReport.Combined)
+	assert.NotNil(t, gotReport.Average)
+	assert.Len(t, gotReport.Entries, 1)
+}

--- a/internal/report/json_test.go
+++ b/internal/report/json_test.go
@@ -229,7 +229,7 @@ func TestJSONFormatter_Format(t *testing.T) {
 			entries: &scan.Entries{},
 			reportCheck: checkJSONFormatterFormatReport(
 				checkReportSchema("https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json"),
-				checkReportVersion("1.0.0"),
+				checkReportVersion("1.1.0"),
 				checkReportEntriesLen(0),
 			),
 		},
@@ -249,7 +249,7 @@ func TestJSONFormatter_Format(t *testing.T) {
 			}},
 			reportCheck: checkJSONFormatterFormatReport(
 				checkReportSchema("https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json"),
-				checkReportVersion("1.0.0"),
+				checkReportVersion("1.1.0"),
 				checkReportEntriesLen(1),
 				checkReportEntries(0,
 					checkEntryFile("/home/user/project/main.go"),
@@ -680,8 +680,7 @@ func TestJSONFormatter_Format_summary_nil_backward_compat(t *testing.T) {
 	s.jsonMarshalIndent = captured
 	err := s.Format(entries, opts)
 	require.NoError(t, err)
-	assert.Nil(t, gotReport.Combined)
-	assert.Nil(t, gotReport.Average)
+	assert.Nil(t, gotReport.Summary)
 }
 
 func TestJSONFormatter_Format_summary_non_nil(t *testing.T) {
@@ -705,10 +704,11 @@ func TestJSONFormatter_Format_summary_non_nil(t *testing.T) {
 	s.jsonMarshalIndent = captured
 	err := s.Format(entries, opts)
 	require.NoError(t, err)
-	require.NotNil(t, gotReport.Combined)
-	require.NotNil(t, gotReport.Average)
-	assert.InDelta(t, combined, *gotReport.Combined, 0.01)
-	assert.InDelta(t, average, *gotReport.Average, 0.01)
+	require.NotNil(t, gotReport.Summary)
+	require.NotNil(t, gotReport.Summary.Combined)
+	require.NotNil(t, gotReport.Summary.Average)
+	assert.InDelta(t, combined, gotReport.Summary.Combined, 0.01)
+	assert.InDelta(t, average, gotReport.Summary.Average, 0.01)
 }
 
 func TestJSONFormatter_Format_summary_with_entries(t *testing.T) {
@@ -729,7 +729,6 @@ func TestJSONFormatter_Format_summary_with_entries(t *testing.T) {
 	s.jsonMarshalIndent = captured
 	err := s.Format(entries, opts)
 	require.NoError(t, err)
-	assert.NotNil(t, gotReport.Combined)
-	assert.NotNil(t, gotReport.Average)
+	assert.NotNil(t, gotReport.Summary)
 	assert.Len(t, gotReport.Entries, 1)
 }

--- a/internal/report/pr_comment.go
+++ b/internal/report/pr_comment.go
@@ -9,7 +9,10 @@ import (
 	"github.com/padiazg/go-crap/internal/score"
 )
 
-func (f *PRCommentFormatter) writePRHeader(w io.Writer, sorted []score.CRAPEntry, crappy []score.CRAPEntry, threshold float64, summary *Summary) {
+const maxPRCommentRows = 25
+const deltaTolerance = 0.01
+
+func (f *PRCommentFormatter) writePRHeader(w io.Writer, sorted []score.CRAPEntry, crappy []score.CRAPEntry, threshold float64, summary *Summary, baseline *Baseline) {
 	fmt.Fprintln(w, "<!-- go-crap-report -->")
 	fmt.Fprintln(w)
 
@@ -21,35 +24,283 @@ func (f *PRCommentFormatter) writePRHeader(w io.Writer, sorted []score.CRAPEntry
 
 	fmt.Fprintf(w, "\n%d function(s) analyzed · threshold %.0f", len(sorted), threshold)
 	if summary != nil {
-		fmt.Fprintf(w, " · Combined CRAP: %.2f | Average CRAP: %.2f", summary.Combined, summary.Average)
+		fmt.Fprintf(w, "\n")
+		fmt.Fprint(w, "\n**CRAP Summary:** ")
+		fmt.Fprintf(w, "Combined CRAP: %.2f", summary.Combined)
+		if baseline != nil && summary.DeltaCombined != 0 {
+			symbol := "+"
+			if summary.DeltaCombined < 0 {
+				symbol = ""
+			}
+			fmt.Fprintf(w, " (%s%.2f vs baseline)", symbol, summary.DeltaCombined)
+		}
+		fmt.Fprint(w, " · ")
+		fmt.Fprintf(w, "Average CRAP: %.2f", summary.Average)
+		if baseline != nil && summary.DeltaAverage != 0 {
+			symbol := "+"
+			if summary.DeltaAverage < 0 {
+				symbol = ""
+			}
+			fmt.Fprintf(w, " (%s%.2f vs baseline)", symbol, summary.DeltaAverage)
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintln(w)
+
+		f.writeBadge(w, summary)
+		fmt.Fprintln(w)
+	} else {
+		fmt.Fprintln(w)
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintln(w)
 }
 
-func (f *PRCommentFormatter) writeCrappyTable(w io.Writer, crappy []score.CRAPEntry, total int, baseDir string) {
+func (f *PRCommentFormatter) writeBadge(w io.Writer, summary *Summary) {
+	if summary == nil || summary.Exceeded == 0 {
+		fmt.Fprint(w, "[OK] All good")
+	} else if summary.TotalFuncs > 0 && summary.Exceeded <= summary.TotalFuncs/2 {
+		fmt.Fprint(w, "[!!] Minor changes")
+	} else {
+		fmt.Fprint(w, "[ERROR] Regressions detected")
+	}
+}
+
+func (f *PRCommentFormatter) writeCrappyTable(w io.Writer, crappy []score.CRAPEntry, total int, baseDir string, baseline *Baseline) {
 	if len(crappy) == 0 {
 		return
 	}
 
-	fmt.Fprintln(w, "| | CRAP | CC | Cov % | Function | Location |")
-	fmt.Fprintln(w, "|---|---:|---:|---:|---|---|")
+	if baseline != nil {
+		fmt.Fprintln(w, "| | CRAP | CC | Cov % | \u0394 | Function | Location |")
+		fmt.Fprintln(w, "|---|---:|---:|---:|---:|---|---|")
 
-	for _, e := range crappy {
-		loc := formatPRLocation(e, baseDir)
-		covStr := fmt.Sprintf("%.1f%%", e.Coverage)
-		if e.CoverageUntrusted {
-			covStr += " \xe2\x9a\xa0"
+		for _, e := range crappy {
+			loc := formatPRLocation(e, baseDir)
+			covStr := fmt.Sprintf("%.1f%%", e.Coverage)
+			if e.CoverageUntrusted {
+				covStr += " \xe2\x9a\xa0"
+			}
+			deltaStr := formatPRDelta(e)
+			fmt.Fprintf(w, "| \xe2\x9c\x97 | %.2f | %d | %s | %s | `%s` | %s |\n",
+				e.EffectiveCRAP, e.Complexity, covStr, deltaStr, e.FuncName, loc)
 		}
-		fmt.Fprintf(w, "| ✗ | %.2f | %d | %s | `%s` | %s |\n",
-			e.EffectiveCRAP, e.Complexity, covStr, e.FuncName, loc)
+	} else {
+		fmt.Fprintln(w, "| | CRAP | CC | Cov % | Function | Location |")
+		fmt.Fprintln(w, "|---|---:|---:|---:|---|---|")
+
+		for _, e := range crappy {
+			loc := formatPRLocation(e, baseDir)
+			covStr := fmt.Sprintf("%.1f%%", e.Coverage)
+			if e.CoverageUntrusted {
+				covStr += " \xe2\x9a\xa0"
+			}
+			fmt.Fprintf(w, "| \xe2\x9c\x97 | %.2f | %d | %s | `%s` | %s |\n",
+				e.EffectiveCRAP, e.Complexity, covStr, e.FuncName, loc)
+		}
 	}
 
 	if total > maxPRCommentRows {
-		fmt.Fprintf(w, "\n…and %d more\n", total-maxPRCommentRows)
+		fmt.Fprintf(w, "\n\xe2\x80\xa6and %d more\n", total-maxPRCommentRows)
 	}
 
 	fmt.Fprintln(w)
+}
+
+func formatPRDelta(e score.CRAPEntry) string {
+	if e.BaselineCRAP < 0 {
+		return "[NEW]"
+	}
+	delta := e.EffectiveCRAP - e.BaselineCRAP
+	if delta > deltaTolerance {
+		return fmt.Sprintf("+%.1f \U0001f534", delta)
+	}
+	if delta < -deltaTolerance {
+		return fmt.Sprintf("%.1f \U0001f7e2", delta)
+	}
+	return "-"
+}
+
+func (f *PRCommentFormatter) writeNewFunctionsSection(w io.Writer, sorted []score.CRAPEntry, baseDir string) {
+	newFuncs := filterNewFunctions(sorted)
+	if len(newFuncs) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "## New Functions")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Function | CRAP | CC | Location |")
+	fmt.Fprintln(w, "|---|---:|---:|---|")
+
+	for _, e := range newFuncs {
+		loc := formatPRLocation(e, baseDir)
+		fmt.Fprintf(w, "| `%s` | %.2f | %d | %s |\n", e.FuncName, e.EffectiveCRAP, e.Complexity, loc)
+	}
+
+	fmt.Fprintln(w)
+}
+
+func (f *PRCommentFormatter) writeRegressionsSection(w io.Writer, sorted []score.CRAPEntry, baseDir string) {
+	regressed := filterRegressions(sorted)
+	if len(regressed) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "## \U0001f534 Regressions")
+	fmt.Fprintln(w)
+
+	sortByDeltaDesc(regressed)
+	fmt.Fprintln(w, "| Function | CRAP | \u0394 | Location |")
+	fmt.Fprintln(w, "|---|---:|---:|---|")
+
+	for _, e := range regressed {
+		loc := formatPRLocation(e, baseDir)
+		delta := e.EffectiveCRAP - e.BaselineCRAP
+		fmt.Fprintf(w, "| `%s` | %.2f | +%.1f | %s |\n", e.FuncName, e.EffectiveCRAP, delta, loc)
+	}
+
+	fmt.Fprintln(w)
+}
+
+func (f *PRCommentFormatter) writeSummaryTable(w io.Writer, summary *Summary, baseline *Baseline, totalFuncs, exceeded int) {
+	if baseline == nil || summary == nil {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "## Summary")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Metric | Baseline | Current | \u0394 |")
+	fmt.Fprintln(w, "|---|---:|---:|---|")
+
+	combinedDeltaStr := formatDeltaStr(summary.DeltaCombined)
+	avgDeltaStr := formatDeltaStr(summary.DeltaAverage)
+	exceededDelta := exceeded - summary.Exceeded
+	var exceededDeltaStr string
+	if exceededDelta != 0 {
+		if exceededDelta > 0 {
+			exceededDeltaStr = fmt.Sprintf("+%d \U0001f534", exceededDelta)
+		} else {
+			exceededDeltaStr = fmt.Sprintf("%d \U0001f7e2", exceededDelta)
+		}
+	}
+
+	fmt.Fprintf(w, "| Combined CRAP | %.1f | %.1f | %s |\n",
+		summary.BaselineCombined, summary.Combined, combinedDeltaStr)
+	fmt.Fprintf(w, "| Average CRAP | %.1f | %.1f | %s |\n",
+		summary.BaselineAverage, summary.Average, avgDeltaStr)
+	fmt.Fprintf(w, "| Functions exceeding threshold | %d | %d | %s |\n",
+		baseline.Summary.TotalFuncs, exceeded, exceededDeltaStr)
+	fmt.Fprintf(w, "| Total functions | %d | %d | |\n",
+		baseline.Summary.TotalFuncs, totalFuncs)
+
+	fmt.Fprintln(w)
+}
+
+func formatDeltaStr(delta float64) string {
+	if delta == 0 {
+		return "-"
+	}
+	if delta > 0 {
+		return fmt.Sprintf("+%.1f \U0001f534", delta)
+	}
+	return fmt.Sprintf("%.1f \U0001f7e2", delta)
+}
+
+func sortByDeltaDesc(entries []score.CRAPEntry) {
+	for i := 0; i < len(entries); i++ {
+		for j := i + 1; j < len(entries); j++ {
+			di := entries[i].EffectiveCRAP - entries[i].BaselineCRAP
+			dj := entries[j].EffectiveCRAP - entries[j].BaselineCRAP
+			if dj > di {
+				entries[i], entries[j] = entries[j], entries[i]
+			}
+		}
+	}
+}
+
+func filterNewFunctions(entries []score.CRAPEntry) []score.CRAPEntry {
+	result := make([]score.CRAPEntry, 0)
+	for _, e := range entries {
+		if e.BaselineCRAP < 0 {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func filterRegressions(entries []score.CRAPEntry) []score.CRAPEntry {
+	result := make([]score.CRAPEntry, 0)
+	for _, e := range entries {
+		if e.BaselineCRAP >= 0 && e.EffectiveCRAP-e.BaselineCRAP > deltaTolerance {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// PRCommentFormatter outputs CRAP entries as a GitHub PR comment.
+type PRCommentFormatter struct{}
+
+func (f *PRCommentFormatter) Format(entries *scan.Entries, opts FormatOptions) error {
+	if entries == nil {
+		return fmt.Errorf("Format: entries list shouldn't be nil")
+	}
+
+	sorted := entries.ForPRComment()
+
+	crappy := filterAboveThreshold(sorted, opts.Threshold)
+
+	f.writePRHeader(opts.Writer, sorted, crappy, opts.Threshold, opts.Summary, opts.Baseline)
+
+	if len(crappy) > maxPRCommentRows {
+		crappy = crappy[:maxPRCommentRows]
+	}
+
+	f.writeCrappyTable(opts.Writer, crappy, len(entries.List), opts.BaseDir, opts.Baseline)
+
+	if opts.Baseline != nil {
+		f.writeNewFunctionsSection(opts.Writer, sorted, opts.BaseDir)
+		f.writeRegressionsSection(opts.Writer, sorted, opts.BaseDir)
+		f.writeSummaryTable(opts.Writer, opts.Summary, opts.Baseline, len(entries.List), 0)
+	}
+
+	unreliable := filterUnreliableCoverage(sorted)
+	f.writeUnreliableSection(opts.Writer, unreliable, opts.Detailed)
+
+	unavailable := filterUnavailableCoverage(sorted)
+	f.writeUnavailableSection(opts.Writer, unavailable)
+
+	return nil
+}
+
+func filterAboveThreshold(entries []score.CRAPEntry, threshold float64) []score.CRAPEntry {
+	result := make([]score.CRAPEntry, 0)
+	for _, e := range entries {
+		if e.EffectiveCRAP > threshold {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func filterUnreliableCoverage(entries []score.CRAPEntry) []score.CRAPEntry {
+	result := make([]score.CRAPEntry, 0)
+	for _, e := range entries {
+		if e.CoverageUntrusted {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func filterUnavailableCoverage(entries []score.CRAPEntry) []score.CRAPEntry {
+	result := make([]score.CRAPEntry, 0)
+	for _, e := range entries {
+		if e.CoverageWarning != "" {
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 func (f *PRCommentFormatter) writeUnreliableSection(w io.Writer, unreliable []score.CRAPEntry, detailed bool) {
@@ -94,67 +345,6 @@ func formatMutantsStr(details []score.MutationDetail) string {
 		}
 	}
 	return mutantsStr.String()
-}
-
-const maxPRCommentRows = 25
-
-// PRCommentFormatter outputs CRAP entries as a GitHub PR comment.
-type PRCommentFormatter struct{}
-
-func (f *PRCommentFormatter) Format(entries *scan.Entries, opts FormatOptions) error {
-	if entries == nil {
-		return fmt.Errorf("Format: entries list shouldn't be nil")
-	}
-
-	sorted := entries.ForPRComment()
-
-	crappy := filterAboveThreshold(sorted, opts.Threshold)
-
-	f.writePRHeader(opts.Writer, sorted, crappy, opts.Threshold, opts.Summary)
-
-	if len(crappy) > maxPRCommentRows {
-		crappy = crappy[:maxPRCommentRows]
-	}
-
-	f.writeCrappyTable(opts.Writer, crappy, len(entries.List), opts.BaseDir)
-
-	unreliable := filterUnreliableCoverage(sorted)
-	f.writeUnreliableSection(opts.Writer, unreliable, opts.Detailed)
-
-	unavailable := filterUnavailableCoverage(sorted)
-	f.writeUnavailableSection(opts.Writer, unavailable)
-
-	return nil
-}
-
-func filterAboveThreshold(entries []score.CRAPEntry, threshold float64) []score.CRAPEntry {
-	result := make([]score.CRAPEntry, 0)
-	for _, e := range entries {
-		if e.EffectiveCRAP > threshold {
-			result = append(result, e)
-		}
-	}
-	return result
-}
-
-func filterUnreliableCoverage(entries []score.CRAPEntry) []score.CRAPEntry {
-	result := make([]score.CRAPEntry, 0)
-	for _, e := range entries {
-		if e.CoverageUntrusted {
-			result = append(result, e)
-		}
-	}
-	return result
-}
-
-func filterUnavailableCoverage(entries []score.CRAPEntry) []score.CRAPEntry {
-	result := make([]score.CRAPEntry, 0)
-	for _, e := range entries {
-		if e.CoverageWarning != "" {
-			result = append(result, e)
-		}
-	}
-	return result
 }
 
 func (f *PRCommentFormatter) writeUnavailableSection(w io.Writer, unavailable []score.CRAPEntry) {

--- a/internal/report/pr_comment.go
+++ b/internal/report/pr_comment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/padiazg/go-crap/internal/score"
 )
 
-func (f *PRCommentFormatter) writePRHeader(w io.Writer, sorted []score.CRAPEntry, crappy []score.CRAPEntry, threshold float64) {
+func (f *PRCommentFormatter) writePRHeader(w io.Writer, sorted []score.CRAPEntry, crappy []score.CRAPEntry, threshold float64, summary *Summary) {
 	fmt.Fprintln(w, "<!-- go-crap-report -->")
 	fmt.Fprintln(w)
 
@@ -19,7 +19,12 @@ func (f *PRCommentFormatter) writePRHeader(w io.Writer, sorted []score.CRAPEntry
 		fmt.Fprintf(w, "## %d crappy function(s)\n", len(crappy))
 	}
 
-	fmt.Fprintf(w, "\n%d function(s) analyzed · threshold %.0f\n\n", len(sorted), threshold)
+	fmt.Fprintf(w, "\n%d function(s) analyzed · threshold %.0f", len(sorted), threshold)
+	if summary != nil {
+		fmt.Fprintf(w, " · Combined CRAP: %.2f | Average CRAP: %.2f", summary.Combined, summary.Average)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w)
 }
 
 func (f *PRCommentFormatter) writeCrappyTable(w io.Writer, crappy []score.CRAPEntry, total int, baseDir string) {
@@ -105,7 +110,7 @@ func (f *PRCommentFormatter) Format(entries *scan.Entries, opts FormatOptions) e
 
 	crappy := filterAboveThreshold(sorted, opts.Threshold)
 
-	f.writePRHeader(opts.Writer, sorted, crappy, opts.Threshold)
+	f.writePRHeader(opts.Writer, sorted, crappy, opts.Threshold, opts.Summary)
 
 	if len(crappy) > maxPRCommentRows {
 		crappy = crappy[:maxPRCommentRows]

--- a/internal/report/pr_comment_test.go
+++ b/internal/report/pr_comment_test.go
@@ -817,3 +817,69 @@ func TestPRCommentFormatter_Format_detailed_unreliable_without_text_fields(t *te
 	assert.Contains(t, output, "`CONTROL_FLOW`@L15")
 	assert.NotContains(t, output, "→")
 }
+
+func TestPRCommentFormatter_Format_summary_nil_backward_compat(t *testing.T) {
+	f := &PRCommentFormatter{}
+	buf := &bytes.Buffer{}
+
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "Foo", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+	}}
+
+	opts := FormatOptions{
+		Threshold: 30,
+		Writer:    buf,
+		Summary:   nil,
+	}
+
+	err := f.Format(entries, opts)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.NotContains(t, output, "Combined CRAP")
+	assert.NotContains(t, output, "Average CRAP")
+	assert.Contains(t, output, "1 function(s) analyzed")
+}
+
+func TestPRCommentFormatter_Format_summary_non_nil(t *testing.T) {
+	f := &PRCommentFormatter{}
+	buf := &bytes.Buffer{}
+
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "Foo", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+		{File: "/project/main.go", Package: "myapp", FuncName: "Bar", Line: 10, Complexity: 10, Coverage: 0, CRAP: 100},
+	}}
+
+	opts := FormatOptions{
+		Threshold: 30,
+		Writer:    buf,
+		Summary:   &Summary{Combined: 101, Average: 50.5, TotalFuncs: 2, Exceeded: 1},
+	}
+
+	err := f.Format(entries, opts)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Combined CRAP: 101.00 | Average CRAP: 50.50")
+	assert.Contains(t, output, "2 function(s) analyzed")
+}
+
+func TestPRCommentFormatter_Format_summary_empty_entries(t *testing.T) {
+	f := &PRCommentFormatter{}
+	buf := &bytes.Buffer{}
+
+	entries := &scan.Entries{List: []score.CRAPEntry{}}
+
+	opts := FormatOptions{
+		Threshold: 30,
+		Writer:    buf,
+		Summary:   &Summary{Combined: 0, Average: 0, TotalFuncs: 0, Exceeded: 0},
+	}
+
+	err := f.Format(entries, opts)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Combined CRAP: 0.00 | Average CRAP: 0.00")
+	assert.Contains(t, output, "0 function(s) analyzed")
+}

--- a/internal/report/pr_comment_test.go
+++ b/internal/report/pr_comment_test.go
@@ -860,7 +860,8 @@ func TestPRCommentFormatter_Format_summary_non_nil(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	assert.Contains(t, output, "Combined CRAP: 101.00 | Average CRAP: 50.50")
+	assert.Contains(t, output, "Combined CRAP: 101.00")
+	assert.Contains(t, output, "Average CRAP: 50.50")
 	assert.Contains(t, output, "2 function(s) analyzed")
 }
 
@@ -880,6 +881,7 @@ func TestPRCommentFormatter_Format_summary_empty_entries(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	assert.Contains(t, output, "Combined CRAP: 0.00 | Average CRAP: 0.00")
+	assert.Contains(t, output, "Combined CRAP: 0.00")
+	assert.Contains(t, output, "Average CRAP: 0.00")
 	assert.Contains(t, output, "0 function(s) analyzed")
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -15,23 +15,23 @@ type Formatter interface {
 // FormatOptions configures report formatting behavior.
 type FormatOptions struct {
 	Writer    io.Writer
+	Baseline  *Baseline
+	Summary   *Summary
 	BaseDir   string
 	Threshold float64
 	Detailed  bool
-	Summary   *Summary
-	Baseline  *Baseline
 }
 
 // Summary holds aggregate CRAP statistics across all functions.
 type Summary struct {
-	Combined          float64
-	Average           float64
-	TotalFuncs        int
-	Exceeded          int
-	BaselineCombined  float64
-	BaselineAverage   float64
-	DeltaCombined     float64
-	DeltaAverage      float64
+	Combined         float64
+	Average          float64
+	TotalFuncs       int
+	Exceeded         int
+	BaselineCombined float64
+	BaselineAverage  float64
+	DeltaCombined    float64
+	DeltaAverage     float64
 }
 
 // ComputeSummary computes aggregate CRAP stats from entries using the given threshold.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -18,6 +18,47 @@ type FormatOptions struct {
 	BaseDir   string
 	Threshold float64
 	Detailed  bool
+	Summary   *Summary
+	Baseline  *Baseline
+}
+
+// Summary holds aggregate CRAP statistics across all functions.
+type Summary struct {
+	Combined          float64
+	Average           float64
+	TotalFuncs        int
+	Exceeded          int
+	BaselineCombined  float64
+	BaselineAverage   float64
+	DeltaCombined     float64
+	DeltaAverage      float64
+}
+
+// ComputeSummary computes aggregate CRAP stats from entries using the given threshold.
+func ComputeSummary(entries *scan.Entries, threshold float64) Summary {
+	if entries == nil {
+		return Summary{}
+	}
+	sorted := entries.ForTable()
+	var combined float64
+	exceeded := 0
+	for _, e := range sorted {
+		combined += e.EffectiveScore()
+		if e.EffectiveScore() > threshold {
+			exceeded++
+		}
+	}
+	total := len(sorted)
+	var avg float64
+	if total > 0 {
+		avg = combined / float64(total)
+	}
+	return Summary{
+		Combined:   combined,
+		Average:    avg,
+		TotalFuncs: total,
+		Exceeded:   exceeded,
+	}
 }
 
 // RelativizePath converts filePath to a path relative to baseDir.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,169 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/padiazg/go-crap/internal/scan"
+	"github.com/padiazg/go-crap/internal/score"
+)
+
+type ComputeSummaryFn func(*testing.T, Summary)
+
+var checkComputeSummary = func(fns ...ComputeSummaryFn) []ComputeSummaryFn { return fns }
+
+func checkSummaryCombined(want float64) ComputeSummaryFn {
+	return func(t *testing.T, s Summary) {
+		t.Helper()
+		assert.InDeltaf(t, want, s.Combined, 0.01, "Combined mismatch")
+	}
+}
+
+func checkSummaryAverage(want float64) ComputeSummaryFn {
+	return func(t *testing.T, s Summary) {
+		t.Helper()
+		assert.InDeltaf(t, want, s.Average, 0.01, "Average mismatch")
+	}
+}
+
+func checkSummaryTotalFuncs(want int) ComputeSummaryFn {
+	return func(t *testing.T, s Summary) {
+		t.Helper()
+		assert.Equalf(t, want, s.TotalFuncs, "TotalFuncs mismatch")
+	}
+}
+
+func checkSummaryExceeded(want int) ComputeSummaryFn {
+	return func(t *testing.T, s Summary) {
+		t.Helper()
+		assert.Equalf(t, want, s.Exceeded, "Exceeded mismatch")
+	}
+}
+
+func TestComputeSummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		entries   *scan.Entries
+		threshold float64
+		checks    []ComputeSummaryFn
+	}{
+		{
+			name:      "success_empty_entries",
+			entries:   &scan.Entries{List: []score.CRAPEntry{}},
+			threshold: 30.0,
+			checks: checkComputeSummary(
+				checkSummaryCombined(0),
+				checkSummaryAverage(0),
+				checkSummaryTotalFuncs(0),
+				checkSummaryExceeded(0),
+			),
+		},
+		{
+			name: "success_single_entry_below_threshold",
+			entries: &scan.Entries{List: []score.CRAPEntry{
+				{File: "/project/main.go", Package: "myapp", FuncName: "Good", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+			}},
+			threshold: 30.0,
+			checks: checkComputeSummary(
+				checkSummaryCombined(1),
+				checkSummaryAverage(1),
+				checkSummaryTotalFuncs(1),
+				checkSummaryExceeded(0),
+			),
+		},
+		{
+			name: "success_single_entry_above_threshold",
+			entries: &scan.Entries{List: []score.CRAPEntry{
+				{File: "/project/main.go", Package: "myapp", FuncName: "Bad", Line: 1, Complexity: 10, Coverage: 0, CRAP: 100},
+			}},
+			threshold: 30.0,
+			checks: checkComputeSummary(
+				checkSummaryCombined(100),
+				checkSummaryAverage(100),
+				checkSummaryTotalFuncs(1),
+				checkSummaryExceeded(1),
+			),
+		},
+		{
+			name: "success_multiple_entries_mixed",
+			entries: &scan.Entries{List: []score.CRAPEntry{
+				{File: "/project/a.go", Package: "myapp", FuncName: "Good", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+				{File: "/project/b.go", Package: "myapp", FuncName: "Warning", Line: 5, Complexity: 4, Coverage: 60, CRAP: 14.4},
+				{File: "/project/c.go", Package: "myapp", FuncName: "Bad", Line: 10, Complexity: 10, Coverage: 0, CRAP: 110},
+			}},
+			threshold: 20.0,
+			checks: checkComputeSummary(
+				checkSummaryCombined(125.4),
+				checkSummaryAverage(41.8),
+				checkSummaryTotalFuncs(3),
+				checkSummaryExceeded(1),
+			),
+		},
+		{
+			name: "success_all_above_threshold",
+			entries: &scan.Entries{List: []score.CRAPEntry{
+				{File: "/project/a.go", Package: "myapp", FuncName: "Bad1", Line: 1, Complexity: 10, Coverage: 0, CRAP: 100},
+				{File: "/project/b.go", Package: "myapp", FuncName: "Bad2", Line: 1, Complexity: 10, Coverage: 0, CRAP: 100},
+			}},
+			threshold: 30.0,
+			checks: checkComputeSummary(
+				checkSummaryCombined(200),
+				checkSummaryAverage(100),
+				checkSummaryTotalFuncs(2),
+				checkSummaryExceeded(2),
+			),
+		},
+		{
+			name: "success_all_below_threshold",
+			entries: &scan.Entries{List: []score.CRAPEntry{
+				{File: "/project/a.go", Package: "myapp", FuncName: "Good1", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+				{File: "/project/b.go", Package: "myapp", FuncName: "Good2", Line: 1, Complexity: 2, Coverage: 100, CRAP: 2},
+			}},
+			threshold: 30.0,
+			checks: checkComputeSummary(
+				checkSummaryCombined(3),
+				checkSummaryAverage(1.5),
+				checkSummaryTotalFuncs(2),
+				checkSummaryExceeded(0),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ComputeSummary(tt.entries, tt.threshold)
+			for _, c := range tt.checks {
+				c(t, r)
+			}
+		})
+	}
+}
+
+func TestComputeSummary_with_effective_score(t *testing.T) {
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/a.go", Package: "myapp", FuncName: "Mutated", Line: 1, Complexity: 4, Coverage: 100, CRAP: 4, EffectiveCRAP: 16},
+		{File: "/project/b.go", Package: "myapp", FuncName: "Normal", Line: 1, Complexity: 2, Coverage: 100, CRAP: 2},
+	}}
+	threshold := 10.0
+	s := ComputeSummary(entries, threshold)
+	require.InDelta(t, 18.0, s.Combined, 0.01)
+	require.InDelta(t, 9.0, s.Average, 0.01)
+	require.Equal(t, 2, s.TotalFuncs)
+	require.Equal(t, 1, s.Exceeded)
+}
+
+func TestRelativizePath_empty_base_dir(t *testing.T) {
+	got := RelativizePath("/project/main.go", "")
+	assert.Equal(t, "/project/main.go", got)
+}
+
+func TestRelativizePath_absolute_base_dir(t *testing.T) {
+	got := RelativizePath("/tmp/project/main.go", "/tmp/project")
+	assert.Equal(t, "main.go", got)
+}
+
+func TestRelativizePath_no_match(t *testing.T) {
+	got := RelativizePath("/other/main.go", "/tmp/project")
+	assert.Equal(t, "../../other/main.go", got)
+}

--- a/internal/report/table.go
+++ b/internal/report/table.go
@@ -19,9 +19,16 @@ func (f *TableFormatter) Format(entries *scan.Entries, opts FormatOptions) error
 
 	sorted := entries.ForTable()
 
+	var header table.Row
+	if opts.Baseline != nil {
+		header = table.Row{"", "CRAP", "CC", "Coverage", "Δ", "Function", "Location"}
+	} else {
+		header = table.Row{"", "CRAP", "CC", "Coverage", "Function", "Location"}
+	}
+
 	t := table.NewWriter()
 	t.SetStyle(table.StyleLight)
-	t.AppendHeader(table.Row{"", "CRAP", "CC", "Coverage", "Function", "Location"})
+	t.AppendHeader(header)
 
 	failed := 0
 	halfThreshold := opts.Threshold / 2.0
@@ -49,7 +56,13 @@ func (f *TableFormatter) Format(entries *scan.Entries, opts FormatOptions) error
 	}
 
 	if opts.Summary != nil {
-		fmt.Fprintf(opts.Writer, "Combined CRAP: %.2f | Average CRAP: %.2f\n", opts.Summary.Combined, opts.Summary.Average)
+		if opts.Baseline != nil {
+			fmt.Fprintf(opts.Writer, "Combined CRAP: %.2f (Δ%.2f vs baseline) | Average CRAP: %.2f (Δ%.2f vs baseline)\n",
+				opts.Summary.Combined, opts.Summary.DeltaCombined,
+				opts.Summary.Average, opts.Summary.DeltaAverage)
+		} else {
+			fmt.Fprintf(opts.Writer, "Combined CRAP: %.2f | Average CRAP: %.2f\n", opts.Summary.Combined, opts.Summary.Average)
+		}
 	}
 
 	if warningSeen {
@@ -77,14 +90,34 @@ func (f *TableFormatter) formatTableRow(e score.CRAPEntry, opts FormatOptions, h
 	loc := f.formatLocation(e, opts.BaseDir)
 	covStr := f.formatCoverageString(e)
 
-	return table.Row{
+	row := table.Row{
 		status,
 		fmt.Sprintf("%.2f", effectiveCRAP),
 		e.Complexity,
 		fmt.Sprintf("%s %s", covBar, covStr),
-		e.FuncName,
-		loc,
 	}
+
+	if opts.Baseline != nil {
+		row = append(row, f.formatDelta(e))
+	}
+
+	row = append(row, e.FuncName, loc)
+
+	return row
+}
+
+func (f *TableFormatter) formatDelta(e score.CRAPEntry) string {
+	if e.BaselineCRAP < 0 {
+		return "\U0001f195 new"
+	}
+	delta := e.EffectiveCRAP - e.BaselineCRAP
+	if delta > deltaTolerance {
+		return fmt.Sprintf("+%.1f \u2191", delta)
+	}
+	if delta < -deltaTolerance {
+		return fmt.Sprintf("%.1f \u2193", delta)
+	}
+	return "-"
 }
 
 func (f *TableFormatter) formatLocation(e score.CRAPEntry, baseDir string) string {

--- a/internal/report/table.go
+++ b/internal/report/table.go
@@ -108,7 +108,7 @@ func (f *TableFormatter) formatTableRow(e score.CRAPEntry, opts FormatOptions, h
 
 func (f *TableFormatter) formatDelta(e score.CRAPEntry) string {
 	if e.BaselineCRAP < 0 {
-		return "\U0001f195 new"
+		return "new"
 	}
 	delta := e.EffectiveCRAP - e.BaselineCRAP
 	if delta > deltaTolerance {

--- a/internal/report/table.go
+++ b/internal/report/table.go
@@ -48,6 +48,10 @@ func (f *TableFormatter) Format(entries *scan.Entries, opts FormatOptions) error
 		fmt.Fprintf(opts.Writer, "%d/%d function(s) exceed threshold CRAP %.0f.\n", failed, total, opts.Threshold)
 	}
 
+	if opts.Summary != nil {
+		fmt.Fprintf(opts.Writer, "Combined CRAP: %.2f | Average CRAP: %.2f\n", opts.Summary.Combined, opts.Summary.Average)
+	}
+
 	if warningSeen {
 		fmt.Fprintln(opts.Writer)
 		for _, e := range sorted {

--- a/internal/report/table_test.go
+++ b/internal/report/table_test.go
@@ -432,3 +432,44 @@ func Test_coverageBar_at_full(t *testing.T) {
 	bar := coverageBar(100.0)
 	assert.Equal(t, "██████████", bar)
 }
+
+func TestTableFormatter_Format_summary_nil_backward_compat(t *testing.T) {
+	f := &TableFormatter{}
+	buf := &bytes.Buffer{}
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "FuncA", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+	}}
+	opts := FormatOptions{Threshold: 30, Writer: buf, Summary: nil}
+	err := f.Format(entries, opts)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.NotContains(t, output, "Combined CRAP")
+	assert.Contains(t, output, "0/1 function(s)")
+}
+
+func TestTableFormatter_Format_summary_non_nil(t *testing.T) {
+	f := &TableFormatter{}
+	buf := &bytes.Buffer{}
+	entries := &scan.Entries{List: []score.CRAPEntry{
+		{File: "/project/main.go", Package: "myapp", FuncName: "Good", Line: 1, Complexity: 1, Coverage: 100, CRAP: 1},
+		{File: "/project/main.go", Package: "myapp", FuncName: "Bad", Line: 10, Complexity: 10, Coverage: 0, CRAP: 100},
+	}}
+	summary := Summary{Combined: 101, Average: 50.5, TotalFuncs: 2, Exceeded: 1}
+	opts := FormatOptions{Threshold: 30, Writer: buf, Summary: &summary}
+	err := f.Format(entries, opts)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "Combined CRAP: 101.00 | Average CRAP: 50.50")
+}
+
+func TestTableFormatter_Format_summary_empty_entries(t *testing.T) {
+	f := &TableFormatter{}
+	buf := &bytes.Buffer{}
+	entries := &scan.Entries{List: []score.CRAPEntry{}}
+	summary := Summary{Combined: 0, Average: 0, TotalFuncs: 0, Exceeded: 0}
+	opts := FormatOptions{Threshold: 30, Writer: buf, Summary: &summary}
+	err := f.Format(entries, opts)
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "Combined CRAP: 0.00 | Average CRAP: 0.00")
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -20,6 +20,7 @@ import (
 var (
 	ErrUnknownPolicy     = errors.New("unknown missing policy")
 	ErrThresholdExceeded = errors.New("CRAP threshold exceeded")
+	ErrRegression        = errors.New("CRAP regression detected")
 )
 
 type Options struct {

--- a/internal/score/score.go
+++ b/internal/score/score.go
@@ -35,6 +35,7 @@ type CRAPEntry struct {
 	Coverage          float64
 	CRAP              float64
 	EffectiveCRAP     float64
+	BaselineCRAP      float64
 	Line              int
 	MutationScore     float64
 	CoverageUntrusted bool


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

Baseline comparison engine: load previous JSON reports, compare CRAP scores, track deltas, and enforce regression thresholds in CI. ASCII badge output for terminal compatibility.

## New flags

- `--baseline <path>` — load a previous JSON report for comparison
- `--fail-regression` — exit code 1 when functions regressed vs baseline
- `--fail-regression-threshold <float>` — minimum delta to trigger (default `0.01`)

## Code changes (15 files, +1917 / -80)

| File | What |
|------|------|
| `internal/report/baseline.go` | `Baseline` struct, `LoadBaseline()`, `Lookup()`, `AnnotateWithBaseline()`, `ComputeSummaryWithBaseline()` |
| `internal/report/baseline_test.go` | 935 lines — full baseline engine tests |
| `internal/report/report.go` | `Summary` struct + `ComputeSummary()`, always displayed in formatters |
| `internal/report/pr_comment.go` | Header with deltas, `[OK]`/`[!!]`/`[ERROR]`/`[NEW]` ASCII badges, "New Functions" & "Regressions" sections, summary table |
| `internal/report/table.go` | `Δ` column when baseline available, delta footer lines |
| `internal/report/json.go` | Schema 1.1.0 — per-entry `baseline_crap`/`delta`, `summary` object with baseline/compare |
| `internal/report/github.go` | `::notice::` summary annotation when baseline provided |
| `internal/scan/scan.go` | `ErrRegression` sentinel error |
| `internal/score/score.go` | `FindRegressions()` exported, `BaselineCRAP`/`Delta` fields on `CRAPEntry` |
| `cmd/scan.go` | `--baseline`, `--fail-regression`, `--fail-regression-threshold` flags wired |
| `*_test.go` (7 files) | 408 lines of new test cases across all packages |

## Documentation (8 files)

| File | What |
|------|------|
| `CHANGELOG.md` | v0.5.0 entries added (partial coverage + baseline) |
| `doc/docs/changelog.md` | Synced with root changelog |
| `doc/docs/index.md` | Baseline Comparison concept section |
| `doc/docs/commands/scan.md` | 3 new flags + 4 baseline example subsections |
| `README.md` | 3 new flags, baseline comparison example, CI update |
| `doc/docs/integrations/index.md` | Baseline provider link, schema version 1.1.0 |
| `doc/docs/integrations/github-actions.md` | Baseline comparison pattern |
| `doc/docs/integrations/baseline-comparison.md` | New — full CI workflow guide |

## Testing

- 664 tests passing
- Build clean, vet clean

## Examples

```shell
# Create a baseline
go-crap scan --format json > baseline.json

# Compare against baseline
go-crap scan --baseline baseline.json

# Enforce regression thresholds in CI
go-crap scan --baseline baseline.json --fail-regression
Migration notes
JSON schema version bumped to 1.1.0. Consumers of the JSON output should expect new fields: baseline_crap, delta, and summary object when --baseline is used. These fields are absent when no baseline is provided.

## Related issues

Closes #46 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added for new functionality
- [x] Documentation updated if needed
