### PR TITLE
feat(install): replace go install with curl installer for pre-built b…

### DIFF
--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           go-version: '1.26.2'
           cache: true
-      - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+      - name: build
+        run: make build
       - name: Generate baseline
-        run: go-crap scan --format json --output crap-current.json
+        run: ./go-crap scan --format json --output crap-current.json
       - uses: actions/upload-artifact@v7
         with:
           name: crap-baseline

--- a/.goreleaser.local.yml
+++ b/.goreleaser.local.yml
@@ -81,7 +81,12 @@ release:
 
     use Go
     ```shell
+    curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
+
+    Or install from source:
+    ```shell
     go install github.com/padiazg/go-crap@{{ .Tag }}
+    ```
     ```
     
     use Homebrew

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,7 +74,12 @@ release:
 
     Download the appropriate binary for your platform below, or:
 
-    use Go
+    Install the pre-built binary with version info stamped via ldflags:
+    ```shell
+    curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
+    ```
+    
+    Or install from source:
     ```shell
     go install github.com/padiazg/go-crap@{{ .Tag }}
     ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CRAP score calculator for Go projects. Calculates the CRAP score (cyclomatic com
 ## Installation
 
 ```shell
-go install github.com/padiazg/go-crap@latest
+curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
 ```
 
 Or build from source:

--- a/doc/docs/concepts/mutation-testing.md
+++ b/doc/docs/concepts/mutation-testing.md
@@ -118,7 +118,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Score
         run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
 
@@ -141,7 +141,7 @@ jobs:
           --integration
           --output=mutation-report.json
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Generate PR comment
         run: >-
           go-crap scan

--- a/doc/docs/getting-started/installation.md
+++ b/doc/docs/getting-started/installation.md
@@ -4,11 +4,29 @@
 
 - Go 1.22 or later
 
+## Install via curl (Recommended)
+
+Install the pre-built binary with version info stamped via ldflags. Prefer this over `go install` which rebuilds from source and loses version/commit/buildDate stamping.
+
+```shell
+curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
+```
+
+Or install a specific version:
+
+```shell
+curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh -s -- -v v0.4.1
+```
+
+The binary is placed in `$GOPATH/bin` (or `$GOBIN` if set). Make sure that directory is in your `PATH`.
+
 ## Install via `go install`
 
 ```shell
 go install github.com/padiazg/go-crap@latest
 ```
+
+> **Note:** `go install` rebuilds the binary from source. The version will show as `v0.0.0 unknown unknown` because ldflags are not applied during `go install`. Use the curl installer above for release binaries with proper version info.
 
 The binary is placed in `$GOPATH/bin` (or `$GOBIN` if set). Make sure that directory is in your `PATH`.
 

--- a/doc/docs/getting-started/quickstart.md
+++ b/doc/docs/getting-started/quickstart.md
@@ -5,7 +5,7 @@ This guide walks through your first CRAP score scan in under two minutes.
 ## 1. Install go-crap
 
 ```shell
-go install github.com/padiazg/go-crap@latest
+curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
 ```
 
 ## 2. Run a Scan

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -83,7 +83,7 @@ When a function has no coverage data, go-crap can handle it three ways:
 
 ```bash
 # Install
-go install github.com/padiazg/go-crap@latest
+curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
 
 # Scan a project
 go-crap scan
@@ -100,7 +100,7 @@ go-crap scan --fail-above --threshold 30
 ## Installation
 
 ```bash
-go install github.com/padiazg/go-crap@latest
+curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
 ```
 
 → [Installation Guide](getting-started/installation.md)

--- a/doc/docs/install.sh
+++ b/doc/docs/install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env sh
+# install.sh — installer for go-crap
+#
+# Usage:
+#   curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
+#   curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh -s -- -v v0.5.0
+#
+# Env vars:
+#   GOPATH or $HOME/bin  — where to put the binary
+#
+# Installs the pre-built binary with version info stamped via ldflags.
+# Prefer this over `go install` which rebuilds from source and loses
+# version/commit/buildDate stamping.
+# Verify with: go-crap version
+
+set -eu
+
+REPO="padiazg/go-crap"
+BINARY="go-crap"
+GITHUB="https://github.com/${REPO}"
+
+VERSION=""
+INSTALL_DIR=""
+
+# ---- arg parsing ----
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -v|--version) VERSION="$2"; shift 2 ;;
+    -d|--dir)     INSTALL_DIR="$2"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+err()  { echo "error: $*" >&2; exit 1; }
+info() { echo ". $*"; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || err "required command '$1' not found"
+}
+
+need_cmd curl
+need_cmd tar
+need_cmd mktemp
+
+# ---- resolve version ----
+if [ -z "$VERSION" ]; then
+  info "Looking up latest release..."
+  LATEST_URL="$(curl -fsS -o /dev/null -D - "${GITHUB}/releases/latest" \
+    | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')"
+  VERSION="${LATEST_URL##*/}"
+  [ -n "$VERSION" ] || err "could not determine latest version; pass -v <tag> explicitly"
+fi
+case "$VERSION" in v*) : ;; *) VERSION="v${VERSION}" ;; esac
+VERSION_NUM="${VERSION#v}"
+
+# ---- detect platform ----
+OS="$(uname -s)"
+case "$OS" in
+  Linux)  OS="linux" ;;
+  Darwin) OS="darwin" ;;
+  *) err "unsupported OS: $OS (only linux and darwin binaries are published)" ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64)        ARCH="amd64" ;;
+  aarch64|arm64)       ARCH="arm64" ;;
+  *) err "unsupported architecture: $ARCH (only amd64 and arm64 are published)" ;;
+esac
+
+ARCHIVE="go-crap_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
+DOWNLOAD_URL="${GITHUB}/releases/download/${VERSION}/${ARCHIVE}"
+CHECKSUMS_URL="${GITHUB}/releases/download/${VERSION}/checksums.txt"
+
+info "Installing ${BINARY} ${VERSION} for ${OS}/${ARCH}"
+
+# ---- resolve install dir ----
+if [ -z "$INSTALL_DIR" ]; then
+  if command -v go >/dev/null 2>&1 && GOPATH="$(go env GOPATH 2>/dev/null)" && [ -n "$GOPATH" ]; then
+    INSTALL_DIR="${GOPATH}/bin"
+  elif [ -w "/usr/local/bin" ] 2>/dev/null; then
+    INSTALL_DIR="/usr/local/bin"
+  else
+    INSTALL_DIR="${HOME}/.local/bin"
+  fi
+fi
+mkdir -p "$INSTALL_DIR" 2>/dev/null || err "cannot create install dir: $INSTALL_DIR"
+[ -w "$INSTALL_DIR" ] || err "install dir not writable: $INSTALL_DIR (try: GSA_INSTALL_DIR=\$HOME/.local/bin sh install.sh)"
+
+# ---- download, verify, extract ----
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+info "Downloading ${ARCHIVE}..."
+curl -fsSL -o "${TMPDIR}/${ARCHIVE}" "$DOWNLOAD_URL" \
+  || err "download failed: $DOWNLOAD_URL"
+
+info "Verifying checksum..."
+curl -fsSL -o "${TMPDIR}/checksums.txt" "$CHECKSUMS_URL" \
+  || err "could not fetch checksums.txt: $CHECKSUMS_URL"
+
+EXPECTED="$(grep " ${ARCHIVE}\$" "${TMPDIR}/checksums.txt" | awk '{print $1}')"
+[ -n "$EXPECTED" ] || err "no checksum entry found for ${ARCHIVE}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL="$(shasum -a 256 "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')"
+else
+  err "need sha256sum or shasum to verify checksum"
+fi
+
+[ "$EXPECTED" = "$ACTUAL" ] || err "checksum mismatch for ${ARCHIVE} (expected ${EXPECTED}, got ${ACTUAL})"
+
+info "Extracting..."
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR" "$BINARY"
+
+install -m 0755 "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}" 2>/dev/null \
+  || { cp "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}" && chmod 0755 "${INSTALL_DIR}/${BINARY}"; }
+
+info "Installed to ${INSTALL_DIR}/${BINARY}"
+
+case ":$PATH:" in
+  *":${INSTALL_DIR}:"*) : ;;
+  *) echo "note: ${INSTALL_DIR} is not on your PATH. Add it, e.g.:"
+     echo "  export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+esac
+
+if command -v "${INSTALL_DIR}/${BINARY}" >/dev/null 2>&1; then
+  "${INSTALL_DIR}/${BINARY}" version
+fi

--- a/doc/docs/integrations/azure-devops.md
+++ b/doc/docs/integrations/azure-devops.md
@@ -19,7 +19,7 @@ steps:
       version: '1.23'
 
   - script: |
-      go install github.com/padiazg/go-crap@latest
+      curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
     displayName: 'Run go-crap'
 ```
@@ -28,7 +28,7 @@ steps:
 
 ```yaml
   - script: |
-      go install github.com/padiazg/go-crap@latest
+      curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       go-crap scan --format json > $(Build.ArtifactStagingDirectory)/crap-report.json --exclude '.*_test\.go'
     displayName: 'Generate CRAP report'
 

--- a/doc/docs/integrations/baseline-comparison.md
+++ b/doc/docs/integrations/baseline-comparison.md
@@ -70,9 +70,9 @@ jobs:
         with:
           go-version: '1.23'
           cache: true
+      - name: Install go-crap
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Generate baseline
-        run: go install github.com/padiazg/go-crap@latest
-      - name: Run go-crap
         run: go-crap scan --format json --output crap-current.json
       - name: Upload baseline
         uses: actions/upload-artifact@v4
@@ -103,7 +103,7 @@ jobs:
           name: crap-baseline
           path: baseline
       - name: Run go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Check for regressions
         run: go-crap scan --baseline baseline/crap-current.json --fail-regression
       - name: Generate PR comment

--- a/doc/docs/integrations/circleci.md
+++ b/doc/docs/integrations/circleci.md
@@ -13,7 +13,7 @@ jobs:
       - checkout
       - run:
           name: Install go-crap
-          command: go install github.com/padiazg/go-crap@latest
+          command: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - run:
           name: Run go-crap
           command: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'

--- a/doc/docs/integrations/gitea.md
+++ b/doc/docs/integrations/gitea.md
@@ -19,7 +19,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap
         run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
 ```

--- a/doc/docs/integrations/github-actions.md
+++ b/doc/docs/integrations/github-actions.md
@@ -35,7 +35,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap
         run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go' --exclude '\.pb\.go$'
 ```
@@ -44,7 +44,7 @@ jobs:
 
 ```yaml
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap with annotations
         run: go-crap scan --format github --threshold 30 --exclude '.*_test\.go'
       - name: Generate JSON report
@@ -74,7 +74,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap
         run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
 ```
@@ -139,7 +139,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Score
         run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
 
@@ -162,7 +162,7 @@ jobs:
           --integration
           --output=mutation-report.json
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Generate PR comment
         run: >-
           go-crap scan
@@ -274,7 +274,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Generate baseline
         run: go-crap scan --format json --output crap-current.json
       - name: Upload baseline
@@ -294,7 +294,7 @@ jobs:
           go-version: '1.23'
           cache: true
       - name: Install go-crap
-        run: go install github.com/padiazg/go-crap@latest
+        run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Download baseline
         uses: actions/download-artifact@v4
         with:

--- a/doc/docs/integrations/gitlab.md
+++ b/doc/docs/integrations/gitlab.md
@@ -11,7 +11,7 @@ crap:
   stage: quality
   image: golang:1.23
   before_script:
-    - go install github.com/padiazg/go-crap@latest
+    - curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
   script:
     - go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
   allow_failure: false
@@ -24,7 +24,7 @@ crap:
   stage: quality
   image: golang:1.23
   before_script:
-    - go install github.com/padiazg/go-crap@latest
+    - curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
   script:
     - go-crap scan --format json > crap-report.json --exclude '.*_test\.go'
   artifacts:

--- a/doc/docs/integrations/jenkins.md
+++ b/doc/docs/integrations/jenkins.md
@@ -13,7 +13,7 @@ pipeline {
     stages {
         stage('Install go-crap') {
             steps {
-                sh "go install github.com/padiazg/go-crap@latest"
+                sh "curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh"
             }
         }
         stage('Run go-crap') {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

Problem
go install rebuilds from source — version shows v0.0.0 unknown unknown because ldflags aren't applied.
Solution
New install.sh downloads pre-built goreleaser archives with checksum verification.
curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
# or specific version
curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh -s -- -v v0.5.0
Changes
- doc/docs/install.sh — new installer (checksums.txt verification, -v/-d flags)
- 12 doc files updated: curl replaces go install everywhere
- CI baseline job: go install → make build
- goreleaser release notes: curl primary, go install as alternative

## Related issues

Closes #54 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added for new functionality
- [x] Documentation updated if needed
