### PR TITLE
fix: deduplicate merged cover profile entries by block position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Partial coverage preserved on test failure — when `go test` fails in a module, go-crap still parses the coverage profile from any passing tests instead of discarding all coverage data
 - `extractFailedTests` helper parses `--- FAIL: TestName` lines from stderr and logs failed test names at Warn level (use `--verbose` to see them)
-- `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaborated by @mem)
-- `--timeout` flag — configurable timeout for the scan command (collaborated by @matiasinsaurralde)
+- `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaboration with @mem)
+- `--timeout` flag — configurable timeout for the scan command (collaboration with @matiasinsaurralde)
 - `Profile` field on `ModuleCoverage` — stores the path to the coverage profile file
 - Baseline comparison engine — load previous JSON reports for delta analysis
 - New `--baseline <path>` flag — compare current CRAP against a previous report
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Coverage profile temp files now cleaned up after successful scan (collaborated by @matiasinsaurralde)
+- Coverage profile deduplication — when `go test -coverprofile` produces a merged profile from multiple test binaries, the same source blocks appeared multiple times. Entries are now deduplicated by `(startLine, endLine)` position using OR semantics (a block is covered if any test binary covered it), fixing inaccurate coverage percentages (reported by @corani)
+- Coverage profile temp files now cleaned up after successful scan (collaboration with @matiasinsaurralde)
 - Field alignment for better memory layout
 - Tests added for `Spash` function
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ mod-tidy:
 	go mod tidy
 
 install: build
-	cp $(BINARY) $(GOPATH)/bin/
+	cp $(BINARY) $(shell go env GOPATH)/bin/
 
 coverage:
 	go test -race -coverprofile=coverage.out ./...

--- a/doc/docs/changelog.md
+++ b/doc/docs/changelog.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Partial coverage preserved on test failure — when `go test` fails in a module, go-crap still parses the coverage profile from any passing tests instead of discarding all coverage data
 - `extractFailedTests` helper parses `--- FAIL: TestName` lines from stderr and logs failed test names at Warn level (use `--verbose` to see them)
-- `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaborated by @mem)
-- `--timeout` flag — configurable timeout for the scan command (collaborated by @matiasinsaurralde)
+- `--coverage-profile` flag — supply an existing coverage profile instead of running `go test` (collaboration with @mem)
+- `--timeout` flag — configurable timeout for the scan command (collaboration with @matiasinsaurralde)
 - `Profile` field on `ModuleCoverage` — stores the path to the coverage profile file
 - Baseline comparison engine — load previous JSON reports for delta analysis
 - New `--baseline <path>` flag — compare current CRAP against a previous report
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Coverage profile temp files now cleaned up after successful scan (collaborated by @matiasinsaurralde)
+- Coverage profile deduplication — when `go test -coverprofile` produces a merged profile from multiple test binaries, the same source blocks appeared multiple times. Entries are now deduplicated by `(startLine, endLine)` position using OR semantics (a block is covered if any test binary covered it), fixing inaccurate coverage percentages (reported by @corani)
+- Coverage profile temp files now cleaned up after successful scan (collaboration with @matiasinsaurralde)
 - Field alignment for better memory layout
 - Tests added for `Spash` function
 

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -55,6 +55,7 @@ Notes:
 
 - If the profile path does not exist, `scan` fails immediately rather than producing an empty report.
 - The same profile is applied to every discovered module; entries whose paths do not belong to a module are skipped.
+- Duplicate block entries from merged coverage profiles (common with `./...` test runs across multiple packages) are automatically deduplicated by `(startLine, endLine)` position using OR semantics — a block is covered if any test binary covered it.
 - When the scan `path` is a package subdirectory that has no `go.mod` of its own, the profile is resolved against the enclosing module (the nearest parent containing a `go.mod`). This lets you point `scan` at a single package:
 
   ```shell

--- a/internal/coverage/parser.go
+++ b/internal/coverage/parser.go
@@ -74,6 +74,7 @@ func parseCoverOutput(r io.Reader) ([]FunctionCoverage, error) {
 type profileEntry struct {
 	path    string
 	start   int
+	end     int
 	covered bool
 }
 
@@ -204,13 +205,26 @@ func buildFuncMap(funcs []fileFunc) (map[string]*funcCoverage, []string) {
 }
 
 func attributeBlocks(fset *token.FileSet, node *ast.File, entries []profileEntry, funcMap map[string]*funcCoverage) {
+	type blockKey struct {
+		start int
+		end   int
+	}
+	seen := make(map[blockKey]bool)
 	for _, e := range entries {
-		fn := findFunctionForBlock(fset, node, e.start)
+		key := blockKey{e.start, e.end}
+		if covered, exists := seen[key]; exists {
+			seen[key] = covered || e.covered
+			continue
+		}
+		seen[key] = e.covered
+	}
+	for key, covered := range seen {
+		fn := findFunctionForBlock(fset, node, key.start)
 		if fn != nil {
-			key := fn.name
-			if fc, ok := funcMap[key]; ok {
+			fc := funcMap[fn.name]
+			if fc != nil {
 				fc.total++
-				if e.covered {
+				if covered {
 					fc.covered++
 				}
 			}
@@ -327,40 +341,42 @@ func parseProfileLine(line string) (profileEntry, error) {
 	entry.path = line[:colonIdx]
 	rest := line[colonIdx+1:]
 
-	startLine, covered, err := parsePositionFields(rest)
+	startLine, endLine, covered, err := parsePositionFields(rest)
 	if err != nil {
 		return entry, err
 	}
 	entry.start = startLine
+	entry.end = endLine
 	entry.covered = covered
 
 	return entry, nil
 }
 
-func parsePositionFields(rest string) (startLine int, covered bool, err error) {
+func parsePositionFields(rest string) (startLine, endLine int, covered bool, err error) {
 	spaceIdx := strings.Index(rest, " ")
 	if spaceIdx <= 0 {
-		return 0, false, fmt.Errorf("invalid line: %s", rest)
+		return 0, 0, false, fmt.Errorf("invalid line: %s", rest)
 	}
 
 	posStr := rest[:spaceIdx]
 	parts := strings.Split(posStr, ",")
 	if len(parts) != 2 {
-		return 0, false, fmt.Errorf("invalid position: %s", posStr)
+		return 0, 0, false, fmt.Errorf("invalid position: %s", posStr)
 	}
 
 	startLine, _ = parseCoord(parts[0])
+	endLine, _ = parseCoord(parts[1])
 
 	coveredStr := strings.Fields(rest[spaceIdx+1:])
 	if len(coveredStr) < 2 {
-		return 0, false, fmt.Errorf("invalid fields: %s", rest)
+		return 0, 0, false, fmt.Errorf("invalid fields: %s", rest)
 	}
 
 	coveredInt, err := strconv.Atoi(coveredStr[1])
 	if err != nil || coveredInt == 0 {
-		return startLine, false, nil
+		return startLine, endLine, false, nil
 	}
-	return startLine, true, nil
+	return startLine, endLine, true, nil
 }
 
 func parseCoord(s string) (line, col int) {

--- a/internal/coverage/parser_test.go
+++ b/internal/coverage/parser_test.go
@@ -547,12 +547,12 @@ func (m *MyType) PointerMethod() {}
 
 func Test_parsePositionFields(t *testing.T) {
 	tests := []struct {
-		name       string
-		rest       string
-		wantStart  int
-		wantEnd    int
+		name        string
+		rest        string
+		wantStart   int
+		wantEnd     int
 		wantCovered bool
-		wantErr    string
+		wantErr     string
 	}{
 		{
 			name:        "normal_covered",

--- a/internal/coverage/parser_test.go
+++ b/internal/coverage/parser_test.go
@@ -255,11 +255,13 @@ func Test_parseProfileLine_boundary_edge_cases(t *testing.T) {
 	entry, err := parseProfileLine("file.go:1.1,5.1 0 0")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, entry.start)
+	assert.Equal(t, 5, entry.end)
 	assert.False(t, entry.covered)
 
 	entry, err = parseProfileLine("file.go:100.1,100.1 1 1")
 	assert.NoError(t, err)
 	assert.Equal(t, 100, entry.start)
+	assert.Equal(t, 100, entry.end)
 	assert.True(t, entry.covered)
 }
 
@@ -331,12 +333,15 @@ func MultipleBlocks() {
 	os.WriteFile(filepath.Join(subDir, "file.go"), []byte(goSrc), 0644)
 	profPath := filepath.Join(tempDir, "cover.out")
 	os.WriteFile(profPath, []byte("mode: set\n"+
-		"mod/path/to/file.go:1.1,10.1 1 0\n"+
-		"mod/path/to/file.go:1.1,10.1 1 1\n"), 0644)
+		"mod/path/to/file.go:4.1,5.1 1 0\n"+
+		"mod/path/to/file.go:4.1,5.1 1 1\n"+
+		"mod/path/to/file.go:5.1,6.1 1 0\n"), 0644)
 
 	entries, err := parseCoverProfile(profPath, tempDir, "mod/path")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, entries)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "MultipleBlocks", entries[0].Name)
+	assert.Equal(t, 50.0, entries[0].Coverage)
 }
 
 func Test_parseCoverProfile_boundary_no_go_files(t *testing.T) {
@@ -542,81 +547,100 @@ func (m *MyType) PointerMethod() {}
 
 func Test_parsePositionFields(t *testing.T) {
 	tests := []struct {
-		name    string
-		rest    string
-		want    int
-		want2   bool
-		wantErr string
+		name       string
+		rest       string
+		wantStart  int
+		wantEnd    int
+		wantCovered bool
+		wantErr    string
 	}{
 		{
-			name:    "normal_covered",
-			rest:    "10.5,20.10 0 1",
-			want:    10,
-			want2:   true,
-			wantErr: "",
+			name:        "normal_covered",
+			rest:        "10.5,20.10 0 1",
+			wantStart:   10,
+			wantEnd:     20,
+			wantCovered: true,
+			wantErr:     "",
 		},
 		{
-			name:    "normal_not_covered",
-			rest:    "10.5,20.10 0 0",
-			want:    10,
-			want2:   false,
-			wantErr: "",
+			name:        "normal_not_covered",
+			rest:        "10.5,20.10 0 0",
+			wantStart:   10,
+			wantEnd:     20,
+			wantCovered: false,
+			wantErr:     "",
 		},
 		{
-			name:    "zero_line",
-			rest:    "0.1,0.1 1 1",
-			want:    0,
-			want2:   true,
-			wantErr: "",
+			name:        "zero_line",
+			rest:        "0.1,0.1 1 1",
+			wantStart:   0,
+			wantEnd:     0,
+			wantCovered: true,
+			wantErr:     "",
 		},
 		{
-			name:    "space_at_position_zero",
-			rest:    " 10.5,20.10 0 1",
-			want:    0,
-			want2:   false,
-			wantErr: "invalid line",
+			name:        "space_at_position_zero",
+			rest:        " 10.5,20.10 0 1",
+			wantStart:   0,
+			wantEnd:     0,
+			wantCovered: false,
+			wantErr:     "invalid line",
 		},
 		{
-			name:    "no_space_in_rest",
-			rest:    "10.5,20.10",
-			want:    0,
-			want2:   false,
-			wantErr: "invalid line",
+			name:        "no_space_in_rest",
+			rest:        "10.5,20.10",
+			wantStart:   0,
+			wantEnd:     0,
+			wantCovered: false,
+			wantErr:     "invalid line",
 		},
 		{
-			name:    "position_without_comma",
-			rest:    "10.5 0 1",
-			want:    0,
-			want2:   false,
-			wantErr: "invalid position",
+			name:        "position_without_comma",
+			rest:        "10.5 0 1",
+			wantStart:   0,
+			wantEnd:     0,
+			wantCovered: false,
+			wantErr:     "invalid position",
 		},
 		{
-			name:    "too_many_comma_parts",
-			rest:    "10.5,20.10,extra 0 1",
-			want:    0,
-			want2:   false,
-			wantErr: "invalid position",
+			name:        "too_many_comma_parts",
+			rest:        "10.5,20.10,extra 0 1",
+			wantStart:   0,
+			wantEnd:     0,
+			wantCovered: false,
+			wantErr:     "invalid position",
 		},
 		{
-			name:    "single_covered_field",
-			rest:    "10.5,20.10 0",
-			want:    0,
-			want2:   false,
-			wantErr: "invalid fields",
+			name:        "single_covered_field",
+			rest:        "10.5,20.10 0",
+			wantStart:   0,
+			wantEnd:     0,
+			wantCovered: false,
+			wantErr:     "invalid fields",
 		},
 		{
-			name:    "non_numeric_covered_value",
-			rest:    "10.5,20.10 0 abc",
-			want:    10,
-			want2:   false,
-			wantErr: "",
+			name:        "non_numeric_covered_value",
+			rest:        "10.5,20.10 0 abc",
+			wantStart:   10,
+			wantEnd:     20,
+			wantCovered: false,
+			wantErr:     "",
+		},
+		{
+			name:        "different_end_line",
+			rest:        "1.1,99.2 1 1",
+			wantStart:   1,
+			wantEnd:     99,
+			wantCovered: true,
+			wantErr:     "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r, r2, err := parsePositionFields(tt.rest)
-			assert.Equal(t, tt.want, r)
-			assert.Equal(t, tt.want2, r2)
+			r, r2, r3, err := parsePositionFields(tt.rest)
+			assert.Equal(t, tt.wantStart, r)
+			assert.Equal(t, tt.wantEnd, r2)
+			assert.Equal(t, tt.wantCovered, r3)
 			if tt.wantErr != "" {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tt.wantErr)

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -79,7 +79,7 @@ func (s *Scanner) Scan(ctx context.Context) ([]ModuleCoverage, error) {
 
 		mc := s.scanModule(ctx, modDir)
 		if mc.Error != nil {
-			s.Logger.Debug("coverage scan: module error", "module", modDir, "error", err.Error())
+			s.Logger.Debug("coverage scan: module error", "module", modDir, "error", mc.Error.Error())
 			mc.Error = fmt.Errorf("scan %s: %w", modDir, mc.Error)
 			results = append(results, mc)
 			continue


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

When `go test -coverprofile` produces a merged profile from multiple
test binaries, the same source blocks appear once per test package.
`attributeBlocks` in `internal/coverage/parser.go` was counting every
raw profile entry without deduplication, causing two kinds of errors:

1. **Coverage can exceed 100%** — if a block appears in more entries
   than another block in the same function, `fc.covered` exceeds
   `fc.total`, producing values like 2888%.
2. **Inaccurate coverage** — even below 100%, the ratio is wrong
   unless all blocks appear with equal frequency. E.g. a function with
   5 unique blocks where 3 are covered gave 6/10 = 60% instead of
   3/5 = 60% (only correct by coincidence).

## Root Cause

`attributeBlocks` iterated raw profile entries and incremented
`fc.total` / `fc.covered` once per entry without deduplicating by
block position first.

## Fix

Three changes in `internal/coverage/parser.go`:

1. **`profileEntry`** — added `end int` field to track block end
   position (previously only `start` was captured).
2. **`parsePositionFields`** — now returns `(startLine, endLine int,
   covered bool, err)` instead of `(startLine int, covered bool, err)`.
3. **`attributeBlocks`** — deduplicates entries by `(startLine,
   endLine)` key using OR semantics (a block is covered if *any* test
   binary covered it), then iterates unique blocks for attribution.

## Additional fixes in this PR

- `Makefile`: use `$(shell go env GOPATH)` instead of bare `$(GOPATH)`
- `scanner.go`: use `mc.Error.Error()` instead of `err.Error()` in log
  message (variable shadowing bug)
- Changelog: attribution style aligned to "collaboration with"

## Related issues

Closes #43 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added for new functionality
- [x] Documentation updated if needed
