### PR TITLE
feat: exclude test files by default

### DIFF
--- a/.github/workflows/crap.yml
+++ b/.github/workflows/crap.yml
@@ -67,9 +67,9 @@ jobs:
       - name: score
         run: |
           if [ -f baseline/crap-current.json ]; then
-            ./go-crap scan --baseline baseline/crap-current.json --format github --fail-above --threshold 30 --exclude ".*_test.go" --verbose
+            ./go-crap scan --baseline baseline/crap-current.json --format github --fail-above --threshold 30 --verbose
           else
-            ./go-crap scan --format github --fail-above --threshold 30 --exclude ".*_test.go" --verbose
+            ./go-crap scan --format github --fail-above --threshold 30 --verbose
           fi
 
       - name: check for regressions
@@ -80,9 +80,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           if [ -f baseline/crap-current.json ]; then
-            ./go-crap scan --baseline baseline/crap-current.json --format pr-comment --threshold 30 --exclude ".*_test.go" --output pr-comment.md
+            ./go-crap scan --baseline baseline/crap-current.json --format pr-comment --threshold 30 --output pr-comment.md
           else
-            ./go-crap scan --format pr-comment --threshold 30 --exclude ".*_test.go" --output pr-comment.md
+            ./go-crap scan --format pr-comment --threshold 30 --output pr-comment.md
           fi
 
       - name: save pr number

--- a/.goreleaser.local.yml
+++ b/.goreleaser.local.yml
@@ -79,14 +79,14 @@ release:
 
     Download the appropriate binary for your platform below, or:
 
-    use Go
+    Install the pre-built binary with version info stamped via ldflags:
     ```shell
     curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
-
+    ```
+    
     Or install from source:
     ```shell
     go install github.com/padiazg/go-crap@{{ .Tag }}
-    ```
     ```
     
     use Homebrew

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ go-crap scan --top 10
 # Fail CI if any function exceeds threshold
 go-crap scan --fail-above --threshold 30
 
-# Exclude test files and protobuf
-go-crap scan --exclude '.*_test\.go' --exclude 'pb/.*\.go'
+# Exclude protobuf files (test files excluded by default)
+go-crap scan --exclude 'pb/.*\.go'
 ```
 
 ### Flags
@@ -64,7 +64,8 @@ go-crap scan --exclude '.*_test\.go' --exclude 'pb/.*\.go'
 | `--top` | | Show only the N worst offenders (0 = all) | `0` |
 | `--min` | | Hide entries below this score | `0` |
 | `--missing` | | Policy for functions without coverage: `pessimistic`, `optimistic`, or `skip` | `pessimistic` |
-| `--exclude` | | Exclude files matching this regex (repeatable). Use `.*` for any path depth. e.g. `.*_test\.go` to exclude all test files, `pb/.*\.go` to exclude protobuf files | none |
+| `--exclude` | | Exclude files matching this regex (repeatable). Use `.*` for any path depth. `_test.go` files are excluded by default | none |
+| `--include-tests` | | Include `_test.go` files in analysis (overrides default exclude) | `false` |
 | `--verbose` | | Enable verbose (debug-level) logging | `false` |
 | `--output` | `-o` | Output file path (default: stdout) | stdout |
 | `--mutation-report` | | Path to gremlins JSON mutation report to validate coverage reliability | `""` |

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -23,6 +23,7 @@ var (
 	flagMin                     float64
 	flagMissing                 string
 	flagExclude                 []string
+	flagIncludeTests            bool
 	flagVerbose                 bool
 	flagOutput                  string
 	flagMutation                string
@@ -55,7 +56,9 @@ func init() {
 	scanCmd.Flags().StringVar(&flagMissing, "missing", "pessimistic",
 		"Policy for functions without coverage: pessimistic|optimistic|skip")
 	scanCmd.Flags().StringArrayVar(&flagExclude, "exclude", nil,
-		"Exclude files matching this regex (repeatable). Use . for any character, .* for any path depth. e.g. '.*_test\\.go' to exclude all test files, 'pb/.*\\.go' to exclude protobuf files")
+		"Exclude files matching this regex (repeatable). Use . for any character, .* for any path depth. _test.go files are excluded by default. e.g. 'pb/.*\\.go' to exclude protobuf files")
+	scanCmd.Flags().BoolVar(&flagIncludeTests, "include-tests", false,
+		"Include _test.go files in analysis (default: excluded)")
 	scanCmd.Flags().BoolVar(&flagVerbose, "verbose", false,
 		"Enable verbose (debug-level) logging")
 	scanCmd.Flags().StringVarP(&flagOutput, "output", "o", "",
@@ -99,6 +102,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	entries, err := scan.Scan(&scan.Options{
 		Exclude:         flagExclude,
+		IncludeTests:    flagIncludeTests,
 		Path:            path,
 		Missing:         flagMissing,
 		Top:             flagTop,

--- a/doc/docs/changelog.md
+++ b/doc/docs/changelog.md
@@ -107,12 +107,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ThresholdExceeded()` now uses `EffectiveCRAP` instead of `CRAP` for threshold comparison
-- Filtering (`--top`, `--min`) and sorting now use `EffectiveCRAP` when mutation report is provided
 - `--fail-above` now checks `EffectiveCRAP` against the threshold
 
 ### Fixed
 
 - Functions with lived mutants now show their true risk level via `EffectiveCRAP` (CRAP at 0% coverage)
+- `--top` no longer drops functions flagged with lived mutation mutants — `CoverageUntrusted` entries always survive truncation alongside the top trusted entries
+- `--min` no longer filters out `CoverageUntrusted` entries, even when their `CRAP` score is below the threshold
+- `github` format now emits `::warning` for `CoverageUntrusted` entries regardless of threshold
+- `pr-comment` format now always renders the "Unreliable Coverage" section when mutation report is provided, even when no function exceeds the CRAP threshold
 
 ## v0.3.0 - 2026-06-05
 

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -25,7 +25,8 @@ go-crap scan [path] [flags]
 | `--min` | | Hide entries below this score. `CoverageUntrusted` entries are never hidden, regardless of their score | `0` |
 | `--missing` | | Policy for functions without coverage: `pessimistic`, `optimistic`, or `skip` | `pessimistic` |
 | `--coverage-profile` | | Use an existing coverage profile (as produced by `go test -coverprofile`) instead of running `go test` | `""` (disabled) |
-| `--exclude` | | Exclude files matching this regex pattern (repeatable). Use `.*` to match any path depth. e.g. `.*_test\.go` to exclude all test files, `pb/.*\.go` to exclude protobuf files | none |
+| `--exclude` | | Exclude files matching this regex pattern (repeatable). `_test.go` files are excluded by default. e.g. `pb/.*\.go` to exclude protobuf files | none |
+| `--include-tests` | | Include `_test.go` files in analysis (overrides default exclude) | `false` |
 | `--verbose` | | Enable verbose (debug-level) logging | `false` |
 | `--output` | `-o` | Output file path (default: stdout) | stdout |
 | `--mutation-report` | | Path to gremlins JSON mutation report to validate coverage reliability | `""` (disabled) |
@@ -114,7 +115,7 @@ go-crap scan --min 10
 ### Exclude generated or test files
 
 ```shell
-go-crap scan --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
+go-crap scan --exclude 'testdata/.*\.go'
 ```
 
 ### Exclude protobuf and mock files at any depth

--- a/doc/docs/concepts/mutation-testing.md
+++ b/doc/docs/concepts/mutation-testing.md
@@ -50,7 +50,7 @@ Combined one-liner:
 
 ```shell
 gremlins unleash --timeout-coefficient 20 -S "l" --integration --output=mutation.json \
-  && go-crap scan --mutation-report mutation.json --exclude ".*_test.go" --top 10
+  && go-crap scan --mutation-report mutation.json --top 10
 ```
 
 Or as separate steps:
@@ -64,7 +64,6 @@ gremlins unleash \
 
 go-crap scan \
   --mutation-report mutation.json \
-  --exclude ".*_test.go" \
   --top 10
 ```
 
@@ -120,7 +119,7 @@ jobs:
       - name: Install go-crap
         run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Score
-        run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
+        run: go-crap scan --fail-above --threshold 30
 
   pr-comment:
     runs-on: ubuntu-latest
@@ -147,7 +146,6 @@ jobs:
           go-crap scan
           --format pr-comment
           --threshold 30
-          --exclude '.*_test\.go'
           --output pr-comment.md
           --mutation-report mutation-report.json || true
       - name: Get PR number

--- a/doc/docs/getting-started/quickstart.md
+++ b/doc/docs/getting-started/quickstart.md
@@ -53,10 +53,10 @@ go-crap scan --top 10
 go-crap scan --min 10
 ```
 
-### Exclude test files and testdata
+### Exclude testdata and generated files
 
 ```shell
-go-crap scan --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
+go-crap scan --exclude 'testdata/.*\.go' --exclude '\.pb\.go$' --exclude 'mock_'
 ```
 
 ### Exclude generated files at any depth

--- a/doc/docs/integrations/azure-devops.md
+++ b/doc/docs/integrations/azure-devops.md
@@ -20,7 +20,7 @@ steps:
 
   - script: |
       curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
-      go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
+      go-crap scan --fail-above --threshold 30 --exclude 'testdata/.*\.go'
     displayName: 'Run go-crap'
 ```
 
@@ -29,7 +29,7 @@ steps:
 ```yaml
   - script: |
       curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
-      go-crap scan --format json > $(Build.ArtifactStagingDirectory)/crap-report.json --exclude '.*_test\.go'
+      go-crap scan --format json > $(Build.ArtifactStagingDirectory)/crap-report.json
     displayName: 'Generate CRAP report'
 
   - task: PublishBuildArtifacts@1

--- a/doc/docs/integrations/circleci.md
+++ b/doc/docs/integrations/circleci.md
@@ -16,7 +16,7 @@ jobs:
           command: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - run:
           name: Run go-crap
-          command: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
+          command: go-crap scan --fail-above --threshold 30 --exclude 'testdata/.*\.go'
 
 workflows:
   quality:

--- a/doc/docs/integrations/gitea.md
+++ b/doc/docs/integrations/gitea.md
@@ -21,7 +21,7 @@ jobs:
       - name: Install go-crap
         run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap
-        run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
+        run: go-crap scan --fail-above --threshold 30 --exclude 'testdata/.*\.go'
 ```
 
 ## Annotations
@@ -30,5 +30,5 @@ Gitea Actions supports GitHub-style `::warning` annotations:
 
 ```yaml
       - name: Run go-crap with annotations
-        run: go-crap scan --format github --threshold 30 --exclude '.*_test\.go'
+        run: go-crap scan --format github --threshold 30
 ```

--- a/doc/docs/integrations/github-actions.md
+++ b/doc/docs/integrations/github-actions.md
@@ -37,7 +37,7 @@ jobs:
       - name: Install go-crap
         run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap
-        run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go' --exclude '\.pb\.go$'
+        run: go-crap scan --fail-above --threshold 30 --exclude 'testdata/.*\.go' --exclude '\.pb\.go$'
 ```
 
 ## PR annotations with JSON report
@@ -46,7 +46,7 @@ jobs:
       - name: Install go-crap
         run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap with annotations
-        run: go-crap scan --format github --threshold 30 --exclude '.*_test\.go'
+        run: go-crap scan --format github --threshold 30
       - name: Generate JSON report
         run: go-crap scan --format json > crap-report.json
       - uses: actions/upload-artifact@v4
@@ -76,14 +76,14 @@ jobs:
       - name: Install go-crap
         run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Run go-crap
-        run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
+        run: go-crap scan --fail-above --threshold 30
 ```
 
 ## SARIF report with code scanning
 
 ```yaml
       - name: Run go-crap with SARIF output
-        run: go-crap scan --format sarif --threshold 30 --exclude '.*_test\.go' > report.sarif
+        run: go-crap scan --format sarif --threshold 30 > report.sarif
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v3
         with:
@@ -96,7 +96,7 @@ SARIF output is compatible with GitHub Advanced Security code scanning, Azure De
 
 ```yaml
       - name: Run go-crap for PR comment
-        run: go-crap scan --format pr-comment --threshold 30 --exclude '.*_test\.go' --output pr-comment.md
+        run: go-crap scan --format pr-comment --threshold 30 --output pr-comment.md
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
@@ -141,7 +141,7 @@ jobs:
       - name: Install go-crap
         run: curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
       - name: Score
-        run: go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
+        run: go-crap scan --fail-above --threshold 30
 
   pr-comment:
     runs-on: ubuntu-latest
@@ -168,7 +168,6 @@ jobs:
           go-crap scan
           --format pr-comment
           --threshold 30
-          --exclude '.*_test\.go'
           --output pr-comment.md
           --mutation-report mutation-report.json || true
       - name: Get PR number

--- a/doc/docs/integrations/gitlab.md
+++ b/doc/docs/integrations/gitlab.md
@@ -13,7 +13,7 @@ crap:
   before_script:
     - curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
   script:
-    - go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go' --exclude 'testdata/.*\.go'
+    - go-crap scan --fail-above --threshold 30 --exclude 'testdata/.*\.go'
   allow_failure: false
 ```
 
@@ -26,7 +26,7 @@ crap:
   before_script:
     - curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
   script:
-    - go-crap scan --format json > crap-report.json --exclude '.*_test\.go'
+    - go-crap scan --format json > crap-report.json
   artifacts:
     paths:
       - crap-report.json

--- a/doc/docs/integrations/index.md
+++ b/doc/docs/integrations/index.md
@@ -19,7 +19,7 @@ Integrate go-crap into your continuous integration pipeline to enforce CRAP scor
 For CI systems with persistent workspaces (not clean checkouts), skip the install step:
 
 ```shell
-go-crap scan --fail-above --threshold 30 --exclude '.*_test\.go'
+go-crap scan --fail-above --threshold 30
 ```
 
 ### Combine exclude patterns
@@ -28,7 +28,6 @@ Multiple `--exclude` flags stack:
 
 ```shell
 go-crap scan \
-  --exclude '.*_test\.go' \
   --exclude 'testdata/.*\.go' \
   --exclude '\.pb\.go$' \
   --exclude 'mock_'
@@ -56,7 +55,7 @@ go-crap scan --fail-above --threshold 15
 
 ```yaml
       - name: Debug scan
-        run: go-crap scan --verbose --format json --exclude '.*_test\.go'
+        run: go-crap scan --verbose --format json
 ```
 
 Use `--verbose` when diagnosing issues with module discovery, coverage parsing, or path matching in CI environments.

--- a/doc/docs/integrations/jenkins.md
+++ b/doc/docs/integrations/jenkins.md
@@ -18,7 +18,7 @@ pipeline {
         }
         stage('Run go-crap') {
             steps {
-                sh "go-crap scan --fail-above --threshold 30 --exclude '.*_test\\.go' --exclude 'testdata/.*\\.go'"
+                sh "go-crap scan --fail-above --threshold 30 --exclude 'testdata/.*\\.go'"
             }
         }
     }

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
   - Integrations:
     - integrations/index.md
     - GitHub Actions: integrations/github-actions.md
+    - Baseline Comparison: integrations/baseline-comparison.md
     - Gitea: integrations/gitea.md
     - GitLab CI: integrations/gitlab.md
     - Azure DevOps: integrations/azure-devops.md

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -30,6 +30,7 @@ type Options struct {
 	MutationReport  string
 	Path            string
 	Exclude         []string
+	IncludeTests    bool
 	Min             float64
 	Timeout         time.Duration
 	Top             int
@@ -52,7 +53,7 @@ func Scan(options *Options) (*Entries, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	exclude, err := utils.BuildExcludeRegex(options.Exclude)
+	exclude, err := utils.BuildExcludeRegex(buildExcludePatterns(options.Exclude, options.IncludeTests))
 	if err != nil {
 		return nil, fmt.Errorf("coverage scan: %w", err)
 	}
@@ -113,4 +114,11 @@ func parseMissingPolicy(s string) (score.MissingPolicy, error) {
 
 func effectiveCRAP(e score.CRAPEntry) float64 {
 	return e.EffectiveScore()
+}
+
+func buildExcludePatterns(userPatterns []string, includeTests bool) []string {
+	if includeTests {
+		return userPatterns
+	}
+	return append([]string{utils.DefaultExcludePattern}, userPatterns...)
 }

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/padiazg/go-crap/internal/coverage"
 	"github.com/padiazg/go-crap/internal/score"
 	"github.com/padiazg/go-crap/pkg/logger"
+	"github.com/padiazg/go-crap/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 )
@@ -69,6 +70,28 @@ func checkSortedDesc() func(*testing.T, *Entries, error) {
 
 // TestScan — integration tests exercising the full Scan pipeline against
 // internal/testdata (real go test + complexity parsing + merge).
+func TestBuildExcludePatterns(t *testing.T) {
+	t.Run("includeTests_true_passes_user_patterns", func(t *testing.T) {
+		got := buildExcludePatterns([]string{`pb/.*`}, true)
+		assert.Equal(t, []string{`pb/.*`}, got)
+	})
+
+	t.Run("includeTests_false_prepends_default", func(t *testing.T) {
+		got := buildExcludePatterns(nil, false)
+		assert.Equal(t, []string{utils.DefaultExcludePattern}, got)
+	})
+
+	t.Run("includeTests_false_composes_user_patterns", func(t *testing.T) {
+		got := buildExcludePatterns([]string{`pb/.*`, `mock_`}, false)
+		assert.Equal(t, []string{utils.DefaultExcludePattern, `pb/.*`, `mock_`}, got)
+	})
+
+	t.Run("includeTests_false_with_nil_user", func(t *testing.T) {
+		got := buildExcludePatterns(nil, false)
+		assert.Equal(t, []string{utils.DefaultExcludePattern}, got)
+	})
+}
+
 func TestScan(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -78,8 +101,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "default_scan_excludes_test_files",
 			options: &Options{
-				Path:    "../testdata",
-				Exclude: []string{".*_test.go"},
+				Path:         "../testdata",
+				IncludeTests: true,
+				Exclude:      []string{".*_test.go"},
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -87,6 +111,32 @@ func TestScan(t *testing.T) {
 				checkValue(0, 90.00, "veryComplex"),
 				checkValue(4, 1.00, "simple"),
 				checkSortedDesc(),
+			},
+		},
+		{
+			name: "default_scan_excludes_test_files_without_explicit_exclude",
+			options: &Options{
+				Path:         "../testdata",
+				IncludeTests: false,
+			},
+			checks: []func(*testing.T, *Entries, error){
+				checkScanError(""),
+				checkLen(5),
+				checkValue(0, 90.00, "veryComplex"),
+				checkValue(4, 1.00, "simple"),
+				checkSortedDesc(),
+			},
+		},
+		{
+			name: "include_tests_flag_includes_test_files",
+			options: &Options{
+				Path:         "../testdata",
+				IncludeTests: true,
+			},
+			checks: []func(*testing.T, *Entries, error){
+				checkScanError(""),
+				checkLen(6),
+				checkValue(0, 90.00, "veryComplex"),
 			},
 		},
 		{
@@ -101,8 +151,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "min_50_filters_low_scores",
 			options: &Options{
-				Path: "../testdata",
-				Min:  50,
+				Path:         "../testdata",
+				IncludeTests: true,
+				Min:          50,
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -113,8 +164,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "min_higher_than_all_returns_empty",
 			options: &Options{
-				Path: "../testdata",
-				Min:  100,
+				Path:         "../testdata",
+				IncludeTests: true,
+				Min:          100,
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -124,8 +176,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "top_2_limits_results",
 			options: &Options{
-				Path: "../testdata",
-				Top:  2,
+				Path:         "../testdata",
+				IncludeTests: true,
+				Top:          2,
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -137,8 +190,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "top_larger_than_result_set_is_no_op",
 			options: &Options{
-				Path: "../testdata",
-				Top:  100,
+				Path:         "../testdata",
+				IncludeTests: true,
+				Top:          100,
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -148,8 +202,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "invalid_missing_policy_returns_error",
 			options: &Options{
-				Path:    "../testdata",
-				Missing: "invalid",
+				Path:         "../testdata",
+				IncludeTests: true,
+				Missing:      "invalid",
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError("unknown missing policy"),
@@ -158,8 +213,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "exclude_function_name_reduces_count",
 			options: &Options{
-				Path:    "../testdata",
-				Exclude: []string{"veryComplex"},
+				Path:         "../testdata",
+				IncludeTests: true,
+				Exclude:      []string{"veryComplex"},
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -170,8 +226,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "missing_optimistic_assumes_100_percent_coverage",
 			options: &Options{
-				Path:    "../testdata",
-				Missing: "optimistic",
+				Path:         "../testdata",
+				IncludeTests: true,
+				Missing:      "optimistic",
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -181,8 +238,9 @@ func TestScan(t *testing.T) {
 		{
 			name: "missing_pessimistic_default_policy",
 			options: &Options{
-				Path:    "../testdata",
-				Missing: "pessimistic",
+				Path:         "../testdata",
+				IncludeTests: true,
+				Missing:      "pessimistic",
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),
@@ -192,7 +250,8 @@ func TestScan(t *testing.T) {
 		{
 			name: "zero_timeout_uses_default",
 			options: &Options{
-				Path: "../testdata",
+				Path:         "../testdata",
+				IncludeTests: true,
 			},
 			checks: []func(*testing.T, *Entries, error){
 				checkScanError(""),

--- a/pkg/utils/ignore_regex.go
+++ b/pkg/utils/ignore_regex.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const DefaultExcludePattern = `.*_test\.go$`
+
 func BuildExcludeRegex(exclude []string) (*regexp.Regexp, error) {
 	if len(exclude) == 0 {
 		return nil, nil

--- a/pkg/utils/ignore_regex_test.go
+++ b/pkg/utils/ignore_regex_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDefaultExcludePattern(t *testing.T) {
+	assert.Equal(t, ".*_test\\.go$", DefaultExcludePattern)
+
+	re, err := regexp.Compile(DefaultExcludePattern)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		filePath string
+		want     bool
+	}{
+		{"main_test.go", true},
+		{"pkg/main_test.go", true},
+		{"vendor/foo/bar/baz_test.go", true},
+		{"main.go", false},
+		{"pkg/helpers.go", false},
+		{"mock_main.go", false},
+		{"_test.go", true},
+	}
+
+	for _, tt := range tests {
+		got := re.MatchString(tt.filePath)
+		assert.Equal(t, tt.want, got, "Match(%q)", tt.filePath)
+	}
+}
+
 func TestMatchExclude(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] CI/CD

## Description

**Exclude `_test.go` files by default.** Previously users had to pass `--exclude '.*_test\.go'` explicitly. Now `_test.go` files are always filtered out unless `--include-tests` is set.

Changes:
- Added `DefaultExcludePattern = ".*_test\\.go$"` constant to `pkg/utils`
- Added `buildExcludePatterns()` in `internal/scan` — prepends the default pattern to user exclude patterns unless `IncludeTests: true`
- Added `--include-tests` flag to `scan` command — overrides the default test-file exclusion
- Updated README: `--exclude` flag description, added `--include-tests` flag, updated examples to no longer show `.*_test\.go` exclusion
- Cleaned up CI workflow — removed redundant `--exclude ".*_test.go"` from all steps since exclusion is now implicit
- Updated tests to pass `IncludeTests: true` where test files are needed, added `buildExcludePatterns` unit tests and `DefaultExcludePattern` regression tests

Also includes doc fixes:
- Added missing Baseline Comparison page to `mkdocs.yml` navigation
- Fixed broken code block formatting in `.goreleaser.local.yml` release header
- Synced `doc/docs/changelog.md` v0.4.0 with root `CHANGELOG.md`

## Related issues

Closes #35 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added for new functionality
- [x] Documentation updated if needed