### PR TITLE
Feat/package pattern scan param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-progress` flag — force-disable progress indicators
 - Progress bars on stderr showing scan phases: "Discovering modules", "Running coverage tests", "Analyzing complexity", "Processing results"
 - Docker images published to `docker.io/padiazg/go-crap` and `ghcr.io/padiazg/go-crap` (multi-arch linux/amd64 + linux/arm64) — run with `docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan`
+- `scan` now accepts multiple Go package patterns (same syntax as `go list` / `go build`): `./...` (recursive), `./pkg` (single), `github.com/x/y` (import path). Patterns resolved via `go list -json -e`, with fallback to path-based discovery for nested modules
+
+### Changed
+
+- No-arg `scan` default changed from current directory (`.`) to whole module (`./...`); accepts multiple positional patterns instead of a single `path` argument
 
 ## v0.5.0 - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ Scans Go packages matching the given patterns (defaults to `./...` — the whole
 
 Patterns use the same syntax as `go list` / `go build`: `./...` (recursive), `./internal/score` (single package), `github.com/x/y` (import path). Multiple patterns are accepted (e.g. `./internal/foo ./internal/bar`).
 
+#### Two-layer selection
+
+go-crap uses two independent mechanisms to narrow what gets analyzed:
+
+1. **Patterns** select which Go *packages* are scanned. Operates at the package/directory level — coverage tests are only run on matching packages.
+2. **`--exclude`** filters *files and functions* within matched packages via regex. Cannot exclude whole packages from being tested, only from the final report.
+
+They are designed to work together:
+
+```shell
+# Scan all packages, but skip generated protobuf files inside them
+go-crap scan --exclude '\.pb\.go$'
+
+# Narrow to specific packages, then exclude files within them
+go-crap scan ./internal/scan ./internal/coverage --exclude 'mock_'
+```
+
 ### Example
 
 ```shell
@@ -95,7 +112,7 @@ go-crap scan --exclude 'pb/.*\.go'
 | `--top` | | Show only the N worst offenders (0 = all) | `0` |
 | `--min` | | Hide entries below this score | `0` |
 | `--missing` | | Policy for functions without coverage: `pessimistic`, `optimistic`, or `skip` | `pessimistic` |
-| `--exclude` | | Exclude files matching this regex (repeatable). Use `.*` for any path depth. `_test.go` files are excluded by default | none |
+| `--exclude` | | Exclude files and functions matching this regex (repeatable). Use `.*` for any path depth. `_test.go` files are excluded by default | none |
 | `--include-tests` | | Include `_test.go` files in analysis (overrides default exclude) | `false` |
 | `--verbose` | | Enable verbose (debug-level) logging | `false` |
 | `--progress` | | Show progress indicators (default: auto-detect terminal) | `false` |

--- a/README.md
+++ b/README.md
@@ -55,19 +55,24 @@ docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan --top 10 --format t
 ## Usage
 
 ```shell
-go-crap scan [path] [flags]
+go-crap scan [pattern ...] [flags]
 ```
 
-Scans the Go module at the given path (defaults to `.`) and outputs a ranked table of functions by CRAP score.
+Scans Go packages matching the given patterns (defaults to `./...` — the whole module) and outputs a ranked table of functions by CRAP score.
+
+Patterns use the same syntax as `go list` / `go build`: `./...` (recursive), `./internal/score` (single package), `github.com/x/y` (import path). Multiple patterns are accepted (e.g. `./internal/foo ./internal/bar`).
 
 ### Example
 
 ```shell
-# Scan current module
+# Scan entire current module (default)
 go-crap scan
 
-# Scan a specific directory
+# Scan specific package
 go-crap scan ./internal/score
+
+# Scan multiple packages
+go-crap scan ./internal/score ./internal/coverage
 
 # Show only the 10 worst offenders
 go-crap scan --top 10

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -43,9 +43,9 @@ var (
 	flagFailRegressionIgnoreCovered bool
 
 	scanCmd = &cobra.Command{
-		Use:   "scan [path]",
+		Use:   "scan [pattern ...]",
 		Short: "Analyze Go modules and calculate CRAP scores",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.MinimumNArgs(0),
 		RunE:  runScan,
 	}
 )
@@ -111,9 +111,9 @@ func resolveProgressReporter() pkgprogress.Reporter {
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
-	path := "."
-	if len(args) > 0 {
-		path = args[0]
+	patterns := args
+	if len(patterns) == 0 {
+		patterns = []string{"./..."}
 	}
 
 	if flagFailRegression && flagBaseline == "" {
@@ -145,7 +145,8 @@ func runScan(cmd *cobra.Command, args []string) error {
 	entries, err := scan.Scan(&scan.Options{
 		Exclude:          flagExclude,
 		IncludeTests:     flagIncludeTests,
-		Path:             path,
+		Path:             patterns[0],
+		Patterns:         patterns,
 		Missing:          flagMissing,
 		Top:              flagTop,
 		Min:              flagMin,
@@ -168,7 +169,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	err = output(entries, outputConfig{
-		path:          path,
+		path:          ".",
 		writer:        cmd.OutOrStdout(),
 		output:        flagOutput,
 		format:        flagFormat,

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -759,7 +759,7 @@ func Test_runScan(t *testing.T) {
 			before: func() {
 				resetFlags()
 				flagFailRegression = true
-		flagBaseline = makeBaselineForTest(t, `{
+				flagBaseline = makeBaselineForTest(t, `{
    "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
    "version": "1.1.0",
    "entries": [
@@ -779,7 +779,7 @@ func Test_runScan(t *testing.T) {
 				resetFlags()
 				flagFailRegression = true
 				flagFailRegressionIgnoreCovered = true
-	flagBaseline = makeBaselineForTest(t, `{
+				flagBaseline = makeBaselineForTest(t, `{
    "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
    "version": "1.1.0",
    "entries": [

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -759,13 +759,13 @@ func Test_runScan(t *testing.T) {
 			before: func() {
 				resetFlags()
 				flagFailRegression = true
-				flagBaseline = makeBaselineForTest(t, `{
-  "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
-  "version": "1.1.0",
-  "entries": [
-    {"file":"simple.go","function":"withIf","package":"testdata","crap":0.1,"cyclomatic":2,"effective_crap":0.1,"line":7,"coverage":0.0},
-    {"file":"complex.go","function":"veryComplex","package":"testdata","crap":0.1,"cyclomatic":10,"effective_crap":0.1,"line":3,"coverage":0.0}
-  ]
+		flagBaseline = makeBaselineForTest(t, `{
+   "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+   "version": "1.1.0",
+   "entries": [
+     {"file":"../internal/testdata/simple.go","function":"withIf","package":"testdata","crap":0.1,"cyclomatic":2,"effective_crap":0.1,"line":7,"coverage":0.0},
+     {"file":"../internal/testdata/complex.go","function":"veryComplex","package":"testdata","crap":0.1,"cyclomatic":10,"effective_crap":0.1,"line":3,"coverage":0.0}
+   ]
 }`)
 			},
 			checks: checkrunScan(
@@ -779,12 +779,12 @@ func Test_runScan(t *testing.T) {
 				resetFlags()
 				flagFailRegression = true
 				flagFailRegressionIgnoreCovered = true
-				flagBaseline = makeBaselineForTest(t, `{
-  "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
-  "version": "1.1.0",
-  "entries": [
-    {"file":"simple.go","function":"simple","package":"testdata","crap":0.1,"cyclomatic":1,"effective_crap":0.1,"line":3,"coverage":100.0}
-  ]
+	flagBaseline = makeBaselineForTest(t, `{
+   "$schema": "https://raw.githubusercontent.com/padiazg/go-crap/main/schemas/report-v1.json",
+   "version": "1.1.0",
+   "entries": [
+     {"file":"../internal/testdata/simple.go","function":"simple","package":"testdata","crap":0.1,"cyclomatic":1,"effective_crap":0.1,"line":3,"coverage":100.0}
+   ]
 }`)
 			},
 			checks: checkrunScan(

--- a/doc/docs/changelog.md
+++ b/doc/docs/changelog.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-progress` flag — force-disable progress indicators
 - Progress bars on stderr showing scan phases: "Discovering modules", "Running coverage tests", "Analyzing complexity", "Processing results"
 - Docker images published to `docker.io/padiazg/go-crap` and `ghcr.io/padiazg/go-crap` (multi-arch linux/amd64 + linux/arm64) — run with `docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan`
+- `scan` now accepts multiple Go package patterns (same syntax as `go list` / `go build`): `./...` (recursive), `./pkg` (single), `github.com/x/y` (import path). Patterns resolved via `go list -json -e`, with fallback to path-based discovery for nested modules
+
+### Changed
+
+- No-arg `scan` default changed from current directory (`.`) to whole module (`./...`); accepts multiple positional patterns instead of a single `path` argument
 
 ## v0.5.0 - 2026-07-28
 

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -40,6 +40,28 @@ go-crap scan ./internal/score ./internal/coverage
 go-crap scan github.com/padiazg/go-crap/internal/...
 ```
 
+## Two-layer selection
+
+go-crap uses two independent mechanisms to narrow what gets analyzed. They operate at different granularities:
+
+1. **Patterns** — select which Go *packages* are scanned. Operates at the package/directory level via `go list` syntax. Choosing whole packages is efficient because coverage tests are only run on matching packages.
+2. **`--exclude`** — filters *files and functions* within matched packages. Operates at the file-path and function-name level via regex. Cannot exclude whole packages from being tested, only from the final report.
+
+They are designed to be used together:
+
+```shell
+# Scan all packages, but skip generated protobuf files inside them
+go-crap scan --exclude '\.pb\.go$'
+
+# Scan only internal/foo, and within that package also exclude testdata files
+go-crap scan ./internal/foo --exclude 'testdata/.*\.go'
+
+# Narrow to specific packages first, then exclude a file pattern within them
+go-crap scan ./internal/scan ./internal/coverage --exclude 'mock_'
+```
+
+Using patterns alone is the right choice when you know which packages to scan. Using `--exclude` is necessary when you need to skip individual files that live inside matched packages — something `go list` cannot do, since Go has no negative package patterns.
+
 ## Flags
 
 | Flag | Short | Description | Default |
@@ -51,7 +73,7 @@ go-crap scan github.com/padiazg/go-crap/internal/...
 | `--min` | | Hide entries below this score. `CoverageUntrusted` entries are never hidden, regardless of their score | `0` |
 | `--missing` | | Policy for functions without coverage: `pessimistic`, `optimistic`, or `skip` | `pessimistic` |
 | `--coverage-profile` | | Use an existing coverage profile (as produced by `go test -coverprofile`) instead of running `go test` | `""` (disabled) |
-| `--exclude` | | Exclude files matching this regex pattern (repeatable). `_test.go` files are excluded by default. e.g. `pb/.*\.go` to exclude protobuf files | none |
+| `--exclude` | | Exclude files and functions matching this regex pattern (repeatable). `_test.go` files are excluded by default. e.g. `pb/.*\.go` to exclude protobuf files | none |
 | `--include-tests` | | Include `_test.go` files in analysis (overrides default exclude) | `false` |
 | `--verbose` | | Enable verbose (debug-level) logging | `false` |
 | `--progress` | | Show progress indicators (default: auto-detect terminal) | `false` |

--- a/doc/docs/commands/scan.md
+++ b/doc/docs/commands/scan.md
@@ -5,14 +5,40 @@ The `scan` command is the main entry point. It analyzes Go modules, computes CRA
 ## Usage
 
 ```shell
-go-crap scan [path] [flags]
+go-crap scan [pattern ...] [flags]
 ```
 
 **Arguments:**
 
 | Argument | Description | Default |
 | - | - | - |
-| `path` | Directory or package pattern to scan | `.` (current directory) |
+| `pattern` | Go package pattern(s) to scan. Accepts any number of patterns. | `./...` (entire module) |
+
+Patterns use the same syntax as `go list` / `go build`:
+
+| Pattern | Meaning |
+| - | - |
+| `.` | Current package |
+| `./...` | Current package and all sub-packages |
+| `./internal/score` | Single package |
+| `./internal/...` | All packages under `internal` |
+| `./internal/foo ./internal/bar` | Multiple specific packages |
+
+Examples:
+
+```shell
+# Scan entire current module (default)
+go-crap scan
+
+# Scan a specific package
+go-crap scan ./internal/score
+
+# Scan multiple packages
+go-crap scan ./internal/score ./internal/coverage
+
+# Scan by import path
+go-crap scan github.com/padiazg/go-crap/internal/...
+```
 
 ## Flags
 
@@ -110,10 +136,22 @@ go-crap scan --no-progress --format json
 go-crap scan
 ```
 
-### Scan a project somewhere else
+### Scan a specific package
 
 ```shell
-go-crap scan ~/go/src/github.com/padiazg/go-crap
+go-crap scan ./internal/scan
+```
+
+### Scan multiple packages
+
+```shell
+go-crap scan ./internal/scan ./internal/coverage
+```
+
+### Scan a project outside the current module
+
+```shell
+go-crap scan ~/go/src/github.com/padiazg/go-crap/...
 ```
 
 ### Show only the top 20 worst offenders
@@ -272,10 +310,16 @@ Generate a JSON report to use as a baseline. Subsequent scans can compare agains
 docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan
 ```
 
-Mount the project directory at `/code` — the container runs `go-crap scan /code` by default. Pass any flags directly:
+Mount the project directory at `/code` — the container analyses whatever directory you mount. Pass any flags directly:
 
 ```shell
-docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan --format json --threshold 30
+docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan --top 10 --format table
 ```
 
-Images are available at `docker.io/padiazg/go-crap` and `ghcr.io/padiazg/go-crap`. Tags map to [releases](https://github.com/padiazg/go-crap/releases).
+To scan a specific package inside the mounted directory:
+
+```shell
+docker run --rm -v "$PWD:/code" ghcr.io/padiazg/go-crap scan ./internal/scan
+```
+
+Images are available at `docker.io/padiazg/go-crap` and `ghcr.io/padiazg/go-crap`. Tags map to [releases](https://github.com/padiazg/go-crap/releases). Multi-arch images (linux/amd64, linux/arm64).

--- a/doc/docs/getting-started/quickstart.md
+++ b/doc/docs/getting-started/quickstart.md
@@ -10,10 +10,17 @@ curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
 
 ## 2. Run a Scan
 
-Point `go-crap scan` at a directory or package pattern:
+`go-crap scan` accepts Go package patterns (same syntax as `go list`). Patterns default to `./...` (the whole module):
 
 ```shell
+# Scan entire current module (default)
 go-crap scan
+
+# Scan a specific package
+go-crap scan ./internal/score
+
+# Scan multiple packages
+go-crap scan ./internal/score ./internal/coverage
 ```
 
 Example output:

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -6,11 +6,20 @@ Inspired by [cargo-crap](https://github.com/Boehs/cargo-crap) for Rust.
 
 ## What It Does
 
-Point it at a directory - it scans all Go modules, computes complexity, reads coverage, and outputs a ranked table of functions by CRAP score:
+`go-crap` accepts Go package patterns (same syntax as `go list`). Point it at a package, multiple packages, or a directory:
 
 ```bash
+# Scan entire current module (default)
 go-crap scan
+
+# Scan specific packages
+go-crap scan ./internal/score ./internal/coverage
+
+# Scan by import path
+go-crap scan github.com/padiazg/go-crap/...
 ```
+
+It scans all Go modules matched by the patterns, computes complexity, reads coverage, and outputs a ranked table of functions by CRAP score.
 
 ## Key Concepts
 
@@ -85,8 +94,11 @@ When a function has no coverage data, go-crap can handle it three ways:
 # Install
 curl -fsSL https://padiazg.github.io/go-crap/install.sh | sh
 
-# Scan a project
+# Scan entire module (default)
 go-crap scan
+
+# Scan specific packages
+go-crap scan ./internal/score ./internal/coverage
 
 # Show only the 10 worst offenders
 go-crap scan --top 10

--- a/internal/complexity/analyze.go
+++ b/internal/complexity/analyze.go
@@ -62,6 +62,52 @@ func Analyze(paths []string, exclude *regexp.Regexp, l logger.Logger) []Stat {
 	return a.stats
 }
 
+// AnalyzeFiles parses the given file paths and returns cyclomatic complexity statistics for each function.
+func AnalyzeFiles(files []string, exclude *regexp.Regexp, l logger.Logger) []Stat {
+	if l == nil {
+		l = dummylogger.New(nil)
+	}
+	var stats []Stat
+	for _, file := range files {
+		if exclude != nil && exclude.MatchString(file) {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, file, nil, parser.ParseComments|parser.AllErrors)
+		if err != nil {
+			l.Debug("complexity analyze: parse error", "file", file, "error", err.Error())
+			continue
+		}
+
+		for _, decl := range f.Decls {
+			fnDecl, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+
+			if parseDirectives(fnDecl.Doc) {
+				continue
+			}
+
+			name := fnDecl.Name.Name
+			if exclude != nil && exclude.MatchString(name) {
+				continue
+			}
+
+			complexity := Complexity(fnDecl)
+			stats = append(stats, Stat{
+				PkgName:    f.Name.Name,
+				FuncName:   name,
+				Receiver:   receiverName(fnDecl.Recv),
+				Complexity: complexity,
+				Pos:        fset.Position(fnDecl.Pos()),
+				EndLine:    fset.Position(fnDecl.End()).Line,
+			})
+		}
+	}
+	return stats
+}
+
 func (a *analyzeData) analyzeDir(dir string) {
 	a.analyzeGoFiles(dir)
 	a.walkSubdirs(dir)

--- a/internal/complexity/analyze_test.go
+++ b/internal/complexity/analyze_test.go
@@ -396,3 +396,31 @@ func Test_newAnalyze(t *testing.T) {
 		})
 	}
 }
+
+type AnalyzeFilesFn func(*testing.T, []Stat)
+
+var checkAnalyzeFiles = func(fns ...AnalyzeFilesFn) []AnalyzeFilesFn { return fns }
+
+func TestAnalyzeFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		exclude *regexp.Regexp
+		l       logger.Logger
+		checks  []AnalyzeFilesFn
+	}{
+		{
+			name:   "TODO: success case",
+			checks: checkAnalyzeFiles(),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := AnalyzeFiles(tt.files, tt.exclude, tt.l)
+			for _, c := range tt.checks {
+				c(t, r)
+			}
+		})
+	}
+}

--- a/internal/complexity/analyze_test.go
+++ b/internal/complexity/analyze_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/padiazg/go-crap/pkg/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComplexity_Simple(t *testing.T) {
@@ -401,23 +402,190 @@ type AnalyzeFilesFn func(*testing.T, []Stat)
 
 var checkAnalyzeFiles = func(fns ...AnalyzeFilesFn) []AnalyzeFilesFn { return fns }
 
+type AnalyzeFilesEntryFn func(*testing.T, Stat)
+
+func checkAnalyzeFilesEntry(i int, fns ...AnalyzeFilesEntryFn) AnalyzeFilesFn {
+	return func(t *testing.T, s []Stat) {
+		t.Helper()
+		require.GreaterOrEqualf(t, len(s), i+1, "Stat has enough entries at index %d", i)
+		entry := s[i]
+		for _, fn := range fns {
+			fn(t, entry)
+		}
+	}
+}
+
+func checkStatFuncName(want string) AnalyzeFilesEntryFn {
+	return func(t *testing.T, s Stat) {
+		t.Helper()
+		assert.Equal(t, want, s.FuncName, "FuncName mismatch")
+	}
+}
+
+func checkStatPkgName(want string) AnalyzeFilesEntryFn {
+	return func(t *testing.T, s Stat) {
+		t.Helper()
+		assert.Equal(t, want, s.PkgName, "PkgName mismatch")
+	}
+}
+
+func checkStatReceiver(want string) AnalyzeFilesEntryFn {
+	return func(t *testing.T, s Stat) {
+		t.Helper()
+		assert.Equal(t, want, s.Receiver, "Receiver mismatch")
+	}
+}
+
+func checkStatComplexity(want int) AnalyzeFilesEntryFn {
+	return func(t *testing.T, s Stat) {
+		t.Helper()
+		assert.Equal(t, want, s.Complexity, "Complexity mismatch")
+	}
+}
+
+func checkStatLine(want int) AnalyzeFilesEntryFn {
+	return func(t *testing.T, s Stat) {
+		t.Helper()
+		assert.Equal(t, want, s.Pos.Line, "Pos.Line mismatch")
+	}
+}
+
+func checkStatEndLine(want int) AnalyzeFilesEntryFn {
+	return func(t *testing.T, s Stat) {
+		t.Helper()
+		assert.Equal(t, want, s.EndLine, "EndLine mismatch")
+	}
+}
+
 func TestAnalyzeFiles(t *testing.T) {
+	checkCount := func(want int) AnalyzeFilesFn {
+		return func(t *testing.T, s []Stat) {
+			t.Helper()
+			assert.Equal(t, want, len(s))
+		}
+	}
+
+	directiveFile := filepath.Join(t.TempDir(), "directive.go")
+	require.NoError(t, os.WriteFile(directiveFile, []byte(`package testdata
+
+//go-crap:ignore
+func ignored() int {
+	if true { return 1 }
+	return 0
+}
+
+func kept() int { return 42 }
+`), 0644))
+
+	receiverFile := filepath.Join(t.TempDir(), "method.go")
+	require.NoError(t, os.WriteFile(receiverFile, []byte(`package testdata
+
+type MyType struct{}
+
+func (m *MyType) Method() int { return 42 }
+`), 0644))
+
+	invalidFile := filepath.Join(t.TempDir(), "invalid.go")
+	require.NoError(t, os.WriteFile(invalidFile, []byte(`package testdata
+func broken(
+`), 0644))
+
+	workDir, err := os.Getwd()
+	require.NoError(t, err)
+	simpleFile := filepath.Join(workDir, "..", "testdata", "simple.go")
+	complexFile := filepath.Join(workDir, "..", "testdata", "complex.go")
+
 	tests := []struct {
 		name    string
 		files   []string
 		exclude *regexp.Regexp
 		l       logger.Logger
+		before  func(*testing.T) []string
 		checks  []AnalyzeFilesFn
 	}{
 		{
-			name:   "TODO: success case",
-			checks: checkAnalyzeFiles(),
+			name:  "success_single_file",
+			files: []string{simpleFile},
+			checks: checkAnalyzeFiles(
+				checkCount(3),
+				checkAnalyzeFilesEntry(0, checkStatFuncName("simple"), checkStatPkgName("testdata"), checkStatComplexity(1), checkStatLine(3), checkStatEndLine(5)),
+				checkAnalyzeFilesEntry(1, checkStatFuncName("withIf"), checkStatComplexity(2), checkStatLine(7), checkStatEndLine(12)),
+				checkAnalyzeFilesEntry(2, checkStatFuncName("complex"), checkStatComplexity(4), checkStatLine(14), checkStatEndLine(25)),
+			),
+		},
+		{
+			name:  "success_multiple_files",
+			files: []string{simpleFile, complexFile},
+			checks: checkAnalyzeFiles(
+				checkCount(5),
+				checkAnalyzeFilesEntry(0, checkStatFuncName("simple"), checkStatComplexity(1)),
+				checkAnalyzeFilesEntry(1, checkStatFuncName("withIf"), checkStatComplexity(2)),
+				checkAnalyzeFilesEntry(2, checkStatFuncName("complex"), checkStatComplexity(4)),
+				checkAnalyzeFilesEntry(3, checkStatFuncName("veryComplex"), checkStatComplexity(9), checkStatLine(3), checkStatEndLine(29)),
+				checkAnalyzeFilesEntry(4, checkStatFuncName("withSwitch"), checkStatComplexity(4), checkStatLine(31), checkStatEndLine(42)),
+			),
+		},
+		{
+			name:    "empty_files",
+			files:   []string{},
+			checks:  checkAnalyzeFiles(checkCount(0)),
+		},
+		{
+			name:    "nonexistent_file_skipped",
+			files:   []string{"nonexistent.go"},
+			l:       nil,
+			checks:  checkAnalyzeFiles(checkCount(0)),
+		},
+		{
+			name:    "exclude_matching_file",
+			files:   []string{simpleFile, complexFile},
+			exclude: regexp.MustCompile(`complex\.go$`),
+			checks:  checkAnalyzeFiles(checkCount(3)),
+		},
+		{
+			name:    "exclude_matching_func",
+			files:   []string{simpleFile},
+			exclude: regexp.MustCompile(`withIf`),
+			checks: checkAnalyzeFiles(
+				checkCount(2),
+				checkAnalyzeFilesEntry(0, checkStatFuncName("simple"), checkStatComplexity(1)),
+				checkAnalyzeFilesEntry(1, checkStatFuncName("complex"), checkStatComplexity(4)),
+			),
+		},
+		{
+			name:    "directive_ignored",
+			files:   []string{directiveFile},
+			exclude: regexp.MustCompile(`ignored`),
+			checks: checkAnalyzeFiles(
+				checkCount(1),
+				checkAnalyzeFilesEntry(0, checkStatFuncName("kept"), checkStatComplexity(1)),
+			),
+		},
+		{
+			name:    "receiver_method",
+			files:   []string{receiverFile},
+			checks: checkAnalyzeFiles(
+				checkCount(1),
+				checkAnalyzeFilesEntry(0, checkStatFuncName("Method"), checkStatReceiver("*MyType"), checkStatComplexity(1)),
+			),
+		},
+		{
+			name:   "parse_error_file_skipped",
+			before: func(t *testing.T) []string {
+				return []string{invalidFile}
+			},
+			l:      nil,
+			checks: checkAnalyzeFiles(checkCount(0)),
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			r := AnalyzeFiles(tt.files, tt.exclude, tt.l)
+			files := tt.files
+			if tt.before != nil {
+				files = tt.before(t)
+			}
+			r := AnalyzeFiles(files, tt.exclude, tt.l)
 			for _, c := range tt.checks {
 				c(t, r)
 			}

--- a/internal/complexity/analyze_test.go
+++ b/internal/complexity/analyze_test.go
@@ -526,15 +526,15 @@ func broken(
 			),
 		},
 		{
-			name:    "empty_files",
-			files:   []string{},
-			checks:  checkAnalyzeFiles(checkCount(0)),
+			name:   "empty_files",
+			files:  []string{},
+			checks: checkAnalyzeFiles(checkCount(0)),
 		},
 		{
-			name:    "nonexistent_file_skipped",
-			files:   []string{"nonexistent.go"},
-			l:       nil,
-			checks:  checkAnalyzeFiles(checkCount(0)),
+			name:   "nonexistent_file_skipped",
+			files:  []string{"nonexistent.go"},
+			l:      nil,
+			checks: checkAnalyzeFiles(checkCount(0)),
 		},
 		{
 			name:    "exclude_matching_file",
@@ -562,15 +562,15 @@ func broken(
 			),
 		},
 		{
-			name:    "receiver_method",
-			files:   []string{receiverFile},
+			name:  "receiver_method",
+			files: []string{receiverFile},
 			checks: checkAnalyzeFiles(
 				checkCount(1),
 				checkAnalyzeFilesEntry(0, checkStatFuncName("Method"), checkStatReceiver("*MyType"), checkStatComplexity(1)),
 			),
 		},
 		{
-			name:   "parse_error_file_skipped",
+			name: "parse_error_file_skipped",
 			before: func(t *testing.T) []string {
 				return []string{invalidFile}
 			},

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -17,6 +17,12 @@ import (
 	"github.com/padiazg/go-crap/pkg/progress"
 )
 
+// ModuleTarget holds per-module package targets for targeted coverage analysis.
+type ModuleTarget struct {
+	ModDir   string
+	PkgDirs  []string // module-relative package directories to run go test on
+}
+
 type Scanner struct {
 	Logger   logger.Logger
 	Progress progress.Reporter
@@ -27,6 +33,10 @@ type Scanner struct {
 	// entries whose paths do not belong to a module are skipped.
 	Profile string
 	Timeout time.Duration
+
+	// Targets, when set, overrides the Path-based module discovery with
+	// explicit per-module package targets.
+	Targets []ModuleTarget
 }
 
 func NewScanner(path string, exclude *regexp.Regexp, logger logger.Logger, timeout time.Duration) *Scanner {
@@ -56,9 +66,18 @@ func (s *Scanner) Scan(ctx context.Context) ([]ModuleCoverage, error) {
 		}
 	}
 
-	modules, err := s.discoverModules(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("discover modules: %w", err)
+	var modules []string
+
+	if len(s.Targets) > 0 {
+		for _, t := range s.Targets {
+			modules = append(modules, t.ModDir)
+		}
+	} else {
+		var err error
+		modules, err = s.discoverModules(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("discover modules: %w", err)
+		}
 	}
 
 	// A supplied profile needs the enclosing module only for path
@@ -76,7 +95,7 @@ func (s *Scanner) Scan(ctx context.Context) ([]ModuleCoverage, error) {
 	}
 
 	var results []ModuleCoverage
-	for _, modDir := range modules {
+	for i, modDir := range modules {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -86,7 +105,13 @@ func (s *Scanner) Scan(ctx context.Context) ([]ModuleCoverage, error) {
 		if s.Progress != nil {
 			s.Progress.SetDetail(filepath.Base(modDir))
 		}
-		mc := s.scanModule(ctx, modDir)
+
+		var pkgDirs []string
+		if i < len(s.Targets) {
+			pkgDirs = s.Targets[i].PkgDirs
+		}
+
+		mc := s.scanModule(ctx, modDir, pkgDirs)
 		if mc.Error != nil {
 			s.Logger.Debug("coverage scan: module error", "module", modDir, "error", mc.Error.Error())
 			mc.Error = fmt.Errorf("scan %s: %w", modDir, mc.Error)
@@ -173,7 +198,7 @@ func walkForModules(root string, visit func(dir string) bool) error {
 	})
 }
 
-func (s *Scanner) scanModule(ctx context.Context, modDir string) ModuleCoverage {
+func (s *Scanner) scanModule(ctx context.Context, modDir string, pkgDirs []string) ModuleCoverage {
 	mc := ModuleCoverage{Dir: modDir}
 	modulePath, err := readModulePath(modDir)
 	if err != nil {
@@ -186,7 +211,7 @@ func (s *Scanner) scanModule(ctx context.Context, modDir string) ModuleCoverage 
 	var parseErr error
 	runTestsSuccess := false
 	if mc.Profile == "" {
-		mc.Profile, err = s.runTests(ctx, modDir)
+		mc.Profile, err = s.runTests(ctx, modDir, pkgDirs)
 		if err != nil {
 			mc.Error = fmt.Errorf("runTests: %w", err)
 		} else {
@@ -225,7 +250,7 @@ func readModulePath(dir string) (string, error) {
 	return "", fmt.Errorf("no module declaration in go.mod")
 }
 
-func (s *Scanner) runTests(ctx context.Context, modDir string) (string, error) {
+func (s *Scanner) runTests(ctx context.Context, modDir string, pkgDirs []string) (string, error) {
 	tmpfile, err := os.CreateTemp("", "coverage-*.out")
 	if err != nil {
 		return "", err
@@ -234,8 +259,15 @@ func (s *Scanner) runTests(ctx context.Context, modDir string) (string, error) {
 		s.Logger.Debug("coverage scan: tmpfile close error", "error", err.Error())
 	}
 	profile := tmpfile.Name()
-	// cmd := exec.CommandContext(ctx, "go", "test", "-coverpkg=./...", "-coverprofile="+profile, "./...")
-	cmd := exec.CommandContext(ctx, "go", "test", "-coverprofile="+profile, "./...")
+
+	args := []string{"test", "-coverprofile=" + profile}
+	if len(pkgDirs) > 0 {
+		args = append(args, pkgDirs...)
+	} else {
+		args = append(args, "./...")
+	}
+
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = modDir
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	var stderr bytes.Buffer

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,8 +20,8 @@ import (
 
 // ModuleTarget holds per-module package targets for targeted coverage analysis.
 type ModuleTarget struct {
-	ModDir   string
-	PkgDirs  []string // module-relative package directories to run go test on
+	ModDir  string
+	PkgDirs []string // module-relative package directories to run go test on
 }
 
 type Scanner struct {
@@ -255,9 +256,7 @@ func (s *Scanner) runTests(ctx context.Context, modDir string, pkgDirs []string)
 	if err != nil {
 		return "", err
 	}
-	if err := tmpfile.Close(); err != nil {
-		s.Logger.Debug("coverage scan: tmpfile close error", "error", err.Error())
-	}
+	_ = tmpfile.Close()
 	profile := tmpfile.Name()
 
 	args := []string{"test", "-coverprofile=" + profile}
@@ -270,12 +269,13 @@ func (s *Scanner) runTests(ctx context.Context, modDir string, pkgDirs []string)
 	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = modDir
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
-	var stderr bytes.Buffer
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
 	cmd.Stderr = &stderr
 
 	err = cmd.Run()
 	if err != nil {
-		if failed := extractFailedTests(stderr.String()); len(failed) > 0 {
+		if failed := extractFailedTests(stdout.String() + stderr.String()); len(failed) > 0 {
 			s.Logger.Warn("coverage: tests failed in module", "module", modDir, "failed_tests", failed)
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/internal/coverage/scanner.go
+++ b/internal/coverage/scanner.go
@@ -33,11 +33,10 @@ type Scanner struct {
 	// "go test". The same profile is applied to every discovered module;
 	// entries whose paths do not belong to a module are skipped.
 	Profile string
-	Timeout time.Duration
-
 	// Targets, when set, overrides the Path-based module discovery with
 	// explicit per-module package targets.
 	Targets []ModuleTarget
+	Timeout time.Duration
 }
 
 func NewScanner(path string, exclude *regexp.Regexp, logger logger.Logger, timeout time.Duration) *Scanner {

--- a/internal/coverage/scanner_test.go
+++ b/internal/coverage/scanner_test.go
@@ -800,7 +800,7 @@ func TestCovered(t *testing.T) {
 				modDir = s.Path
 			}
 			ctx := context.Background()
-			r := s.scanModule(ctx, modDir)
+			r := s.scanModule(ctx, modDir, nil)
 			for _, c := range tt.checks {
 				c(t, r)
 			}
@@ -927,7 +927,7 @@ func Something() {}
 				modDir = s.Path
 			}
 			ctx := context.Background()
-			r, err := s.runTests(ctx, modDir)
+			r, err := s.runTests(ctx, modDir, nil)
 			defer func() {
 				if removeErr := os.Remove(r); removeErr != nil {
 					assert.NoError(t, removeErr)
@@ -963,7 +963,7 @@ func Nothing() {}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := s.runTests(ctx, tempDir)
+	_, err := s.runTests(ctx, tempDir, nil)
 	assert.Error(t, err)
 }
 
@@ -997,7 +997,7 @@ func TestSlow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	_, err := s.runTests(ctx, tempDir)
+	_, err := s.runTests(ctx, tempDir, nil)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "timed out")
 		assert.Contains(t, err.Error(), "--timeout")
@@ -1035,7 +1035,7 @@ func broken( {
 	s := NewScanner("value", nil, logger, 0)
 
 	ctx := context.Background()
-	_, err := s.runTests(ctx, tempDir)
+	_, err := s.runTests(ctx, tempDir, nil)
 	assert.Error(t, err)
 	assert.NotContains(t, logger.warns, "coverage: tests failed in module", "no failed tests to report")
 }

--- a/internal/coverage/scanner_test.go
+++ b/internal/coverage/scanner_test.go
@@ -1147,6 +1147,58 @@ func broken( {
 	assert.NotContains(t, logger.warns, "coverage: tests failed in module", "no failed tests to report")
 }
 
+func TestScanner_runTests_createtemp_failure(t *testing.T) {
+	tempDir := t.TempDir()
+	goMod := `module tempmod
+
+go 1.21
+`
+	os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goMod), 0644)
+	src := `package tempmod
+
+func Something() {}
+`
+	os.WriteFile(filepath.Join(tempDir, "pkg.go"), []byte(src), 0644)
+
+	s := NewScanner("value", nil, nil, 0)
+
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent"))
+
+	_, err := s.runTests(context.Background(), tempDir, nil)
+	assert.Error(t, err)
+}
+
+func TestScanner_runTests_warns_on_failed_tests(t *testing.T) {
+	tempDir := t.TempDir()
+	goMod := `module warnmod
+
+go 1.21
+`
+	os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goMod), 0644)
+	src := `package warnmod
+
+func Something() int { return 42 }
+`
+	os.WriteFile(filepath.Join(tempDir, "pkg.go"), []byte(src), 0644)
+	test := `package warnmod
+
+import "testing"
+
+func TestFail(t *testing.T) {
+	t.Fatal("intentional failure")
+}
+`
+	os.WriteFile(filepath.Join(tempDir, "pkg_test.go"), []byte(test), 0644)
+
+	logger := &recordingLogger{}
+	s := NewScanner("value", nil, logger, 0)
+
+	ctx := context.Background()
+	_, err := s.runTests(ctx, tempDir, nil)
+	assert.Error(t, err)
+	assert.Contains(t, logger.warns, "coverage: tests failed in module")
+}
+
 type checkScannerfilterByExcludeFn func(*testing.T, []FunctionCoverage)
 
 var checkScannerfilterByExclude = func(fns ...checkScannerfilterByExcludeFn) []checkScannerfilterByExcludeFn { return fns }

--- a/internal/coverage/scanner_test.go
+++ b/internal/coverage/scanner_test.go
@@ -395,6 +395,113 @@ func TestScanner_Scan(t *testing.T) {
 				s.Progress = &mockProgressReporter{}
 			},
 		},
+		{
+			name: "targets_override_path_discovery",
+			checks: checkScannerScan(
+				checkError(""),
+				func(t *testing.T, r []ModuleCoverage, err error) {
+					t.Helper()
+					require.Len(t, r, 1)
+				},
+			),
+			before: func(s *Scanner) {
+				parent := t.TempDir()
+				for _, name := range []string{"modA", "modB"} {
+					modDir := filepath.Join(parent, name)
+					os.MkdirAll(modDir, 0755)
+					os.WriteFile(filepath.Join(modDir, "go.mod"), fmt.Appendf(nil, "module %s\n\ngo 1.21\n", name), 0644)
+					os.WriteFile(filepath.Join(modDir, "pkg.go"), fmt.Appendf(nil, "package %s\n\nfunc Something() int { return 42 }\n", name), 0644)
+					os.WriteFile(filepath.Join(modDir, "pkg_test.go"), fmt.Appendf(nil, "package %s\n\nimport \"testing\"\n\nfunc TestSuccess(t *testing.T) {\n\tif 1+1 != 2 {\n\t\tt.Error(\"math broken\")\n\t}\n}\n", name), 0644)
+				}
+				s.Path = parent
+				s.Targets = []ModuleTarget{{ModDir: filepath.Join(parent, "modA")}}
+			},
+		},
+		{
+			name: "targets_multiple_modules",
+			checks: checkScannerScan(
+				checkError(""),
+				func(t *testing.T, r []ModuleCoverage, err error) {
+					t.Helper()
+					require.Len(t, r, 2)
+				},
+			),
+			before: func(s *Scanner) {
+				parent := t.TempDir()
+				for _, name := range []string{"modA", "modB"} {
+					modDir := filepath.Join(parent, name)
+					os.MkdirAll(modDir, 0755)
+					os.WriteFile(filepath.Join(modDir, "go.mod"), fmt.Appendf(nil, "module %s\n\ngo 1.21\n", name), 0644)
+					os.WriteFile(filepath.Join(modDir, "pkg.go"), fmt.Appendf(nil, "package %s\n\nfunc Something() int { return 42 }\n", name), 0644)
+					os.WriteFile(filepath.Join(modDir, "pkg_test.go"), fmt.Appendf(nil, "package %s\n\nimport \"testing\"\n\nfunc TestSuccess(t *testing.T) {\n\tif 1+1 != 2 {\n\t\tt.Error(\"math broken\")\n\t}\n}\n", name), 0644)
+				}
+				s.Targets = []ModuleTarget{
+					{ModDir: filepath.Join(parent, "modA")},
+					{ModDir: filepath.Join(parent, "modB")},
+				}
+			},
+		},
+		{
+			name: "targets_with_pkgdirs_limits_scope",
+			checks: checkScannerScan(
+				checkError(""),
+				func(t *testing.T, r []ModuleCoverage, err error) {
+					t.Helper()
+					require.Len(t, r, 1)
+					assert.NotEmpty(t, r[0].Dir)
+					assert.NotEmpty(t, r[0].Functions)
+					// PkgDirs should have restricted go test to sub package,
+					// so only Sub() should appear — Root() from the root package
+					// must be absent.
+					var foundRoot, foundSub bool
+					for _, f := range r[0].Functions {
+						if f.Name == "Root" {
+							foundRoot = true
+						}
+						if f.Name == "Sub" {
+							foundSub = true
+						}
+					}
+					assert.True(t, foundSub, "expected Sub() in coverage results")
+					assert.False(t, foundRoot, "expected Root() NOT in coverage results (only sub package scanned)")
+				},
+			),
+			before: func(s *Scanner) {
+				modDir := t.TempDir()
+				os.WriteFile(filepath.Join(modDir, "go.mod"), []byte("module pkgtest\n\ngo 1.21\n"), 0644)
+				// root package
+				os.WriteFile(filepath.Join(modDir, "root.go"), []byte("package pkgtest\n\nfunc Root() int { return 1 }\n"), 0644)
+				os.WriteFile(filepath.Join(modDir, "root_test.go"), []byte("package pkgtest\n\nimport \"testing\"\n\nfunc TestRoot(t *testing.T) { Root() }\n"), 0644)
+				// sub package
+				subDir := filepath.Join(modDir, "internal", "sub")
+				os.MkdirAll(subDir, 0755)
+				os.WriteFile(filepath.Join(subDir, "sub.go"), []byte("package sub\n\nfunc Sub() int { return 2 }\n"), 0644)
+				os.WriteFile(filepath.Join(subDir, "sub_test.go"), []byte("package sub\n\nimport \"testing\"\n\nfunc TestSub(t *testing.T) { Sub() }\n"), 0644)
+				s.Targets = []ModuleTarget{
+					{ModDir: modDir, PkgDirs: []string{subDir}},
+				}
+			},
+		},
+		{
+			name: "targets_empty_pkgdirs_runs_all",
+			checks: checkScannerScan(
+				checkError(""),
+				func(t *testing.T, r []ModuleCoverage, err error) {
+					t.Helper()
+					require.Len(t, r, 1)
+					assert.NotEmpty(t, r[0].Functions)
+				},
+			),
+			before: func(s *Scanner) {
+				modDir := t.TempDir()
+				os.WriteFile(filepath.Join(modDir, "go.mod"), []byte("module emptypkg\n\ngo 1.21\n"), 0644)
+				os.WriteFile(filepath.Join(modDir, "pkg.go"), []byte("package emptypkg\n\nfunc Something() int { return 42 }\n"), 0644)
+				os.WriteFile(filepath.Join(modDir, "pkg_test.go"), []byte("package emptypkg\n\nimport \"testing\"\n\nfunc TestSomething(t *testing.T) { Something() }\n"), 0644)
+				s.Targets = []ModuleTarget{
+					{ModDir: modDir},
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -39,15 +37,42 @@ type listPackage struct {
 	Error        packageError
 }
 
+type ResolverConfig struct {
+	Runner GoListRunner
+}
+
+// Resolver resolves package patterns via `go list -json -e`.
+type Resolver struct {
+	runner GoListRunner
+}
+
+// NewResolver creates a Resolver with the given options.
+// Defaults to the real GoListRunner.
+func NewResolver(config *ResolverConfig) *Resolver {
+	if config == nil {
+		config = &ResolverConfig{}
+	}
+
+	if config.Runner == nil {
+		config.Runner = NewGoListRunner()
+	}
+
+	return &Resolver{
+		runner: config.Runner,
+	}
+}
+
 // Resolve resolves package patterns via `go list -json -e`.
-func Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Target, error) {
-	stdout, err := getList(ctx, patterns)
+func (r *Resolver) Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Target, error) {
+	stdout, err := r.runner.List(ctx, patterns)
 	if err != nil {
 		return nil, err
 	}
 
-	// Stream JSON objects (one per package) from the combined output.
-	targets, errors, err := getTargets(stdout, includeTests)
+	var b bytes.Buffer
+	b.Write(stdout)
+
+	targets, errors, err := getTargets(&b, includeTests)
 	if err != nil {
 		return nil, err
 	}
@@ -57,30 +82,6 @@ func Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Targe
 	}
 
 	return targets, nil
-}
-
-func getList(ctx context.Context, patterns []string) (*bytes.Buffer, error) {
-	args := []string{"list", "-e", "-json"}
-	args = append(args, patterns...)
-
-	cmd := exec.CommandContext(ctx, "go", args...)
-	cmd.Dir = "."
-	cmd.Env = append(os.Environ(), "GO111MODULE=on")
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if err != nil {
-		// -e flag means errors are per-package in JSON; command may still exit non-zero
-		// for patterns that resolve to no packages at all.
-		if stdout.Len() == 0 {
-			msg := "go list: " + stderr.String()
-			return nil, fmt.Errorf("resolve patterns: %w\n%s", err, msg)
-		}
-	}
-
-	return &stdout, nil
 }
 
 func getTargets(stdout *bytes.Buffer, includeTests bool) ([]Target, []string, error) {

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -1,0 +1,105 @@
+package packages
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Target represents a single Go package resolved from a pattern.
+type Target struct {
+	ImportPath string
+	Dir        string
+	Files      []string
+	TestFiles  []string
+	ModulePath string
+	ModuleDir  string
+}
+
+// Resolve resolves package patterns via `go list -json -e`.
+func Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Target, error) {
+	args := []string{"list", "-e", "-json"}
+	args = append(args, patterns...)
+
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		// -e flag means errors are per-package in JSON; command may still exit non-zero
+		// for patterns that resolve to no packages at all.
+		if stdout.Len() == 0 {
+			msg := "go list: " + stderr.String()
+			return nil, fmt.Errorf("resolve patterns: %w\n%s", err, msg)
+		}
+	}
+
+	// Stream JSON objects (one per package) from the combined output.
+	dec := json.NewDecoder(&stdout)
+	var targets []Target
+	var errors []string
+
+	for dec.More() {
+		var pkg listPackage
+		if err := dec.Decode(&pkg); err != nil {
+			return nil, fmt.Errorf("resolve patterns: decode JSON: %w", err)
+		}
+		if pkg.Error.Err != "" {
+			errors = append(errors, fmt.Sprintf("%s: %s", pkg.ImportPath, pkg.Error.Err))
+			continue
+		}
+
+		t := Target{
+			ImportPath: pkg.ImportPath,
+			Dir:        pkg.Dir,
+			ModulePath: pkg.ModulePath,
+			ModuleDir:  pkg.ModuleDir,
+		}
+
+		// Convert relative GoFiles to absolute paths.
+		for _, f := range pkg.GoFiles {
+			abs := filepath.Join(pkg.Dir, f)
+			t.Files = append(t.Files, abs)
+		}
+
+		if includeTests {
+			for _, f := range append(pkg.TestGoFiles, pkg.XTestGoFiles...) {
+				abs := filepath.Join(pkg.Dir, f)
+				t.TestFiles = append(t.TestFiles, abs)
+			}
+		}
+
+		targets = append(targets, t)
+	}
+
+	if len(targets) == 0 && len(errors) > 0 {
+		return nil, fmt.Errorf("resolve patterns: %s", strings.Join(errors, "; "))
+	}
+
+	return targets, nil
+}
+
+// listPackage is a minimal representation of go list -json output for a package.
+type listPackage struct {
+	ImportPath  string
+	Dir         string
+	ModulePath  string
+	ModuleDir   string
+	GoFiles     []string
+	TestGoFiles []string
+	XTestGoFiles []string
+	Error       struct {
+		ImportPath string
+		Pos        string
+		Err        string
+	}
+}

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -21,8 +21,45 @@ type Target struct {
 	ModuleDir  string
 }
 
+type packageError struct {
+	ImportPath string
+	Pos        string
+	Err        string
+}
+
+// listPackage is a minimal representation of go list -json output for a package.
+type listPackage struct {
+	ImportPath   string
+	Dir          string
+	ModulePath   string
+	ModuleDir    string
+	GoFiles      []string
+	TestGoFiles  []string
+	XTestGoFiles []string
+	Error        packageError
+}
+
 // Resolve resolves package patterns via `go list -json -e`.
 func Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Target, error) {
+	stdout, err := getList(ctx, patterns)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stream JSON objects (one per package) from the combined output.
+	targets, errors, err := getTargets(stdout, includeTests)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(targets) == 0 && len(errors) > 0 {
+		return nil, fmt.Errorf("resolve patterns: %s", strings.Join(errors, "; "))
+	}
+
+	return targets, nil
+}
+
+func getList(ctx context.Context, patterns []string) (*bytes.Buffer, error) {
 	args := []string{"list", "-e", "-json"}
 	args = append(args, patterns...)
 
@@ -43,16 +80,20 @@ func Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Targe
 		}
 	}
 
-	// Stream JSON objects (one per package) from the combined output.
-	dec := json.NewDecoder(&stdout)
+	return &stdout, nil
+}
+
+func getTargets(stdout *bytes.Buffer, includeTests bool) ([]Target, []string, error) {
+	dec := json.NewDecoder(stdout)
 	var targets []Target
 	var errors []string
 
 	for dec.More() {
 		var pkg listPackage
 		if err := dec.Decode(&pkg); err != nil {
-			return nil, fmt.Errorf("resolve patterns: decode JSON: %w", err)
+			return nil, nil, fmt.Errorf("resolve patterns: decode JSON: %w", err)
 		}
+
 		if pkg.Error.Err != "" {
 			errors = append(errors, fmt.Sprintf("%s: %s", pkg.ImportPath, pkg.Error.Err))
 			continue
@@ -81,25 +122,5 @@ func Resolve(ctx context.Context, patterns []string, includeTests bool) ([]Targe
 		targets = append(targets, t)
 	}
 
-	if len(targets) == 0 && len(errors) > 0 {
-		return nil, fmt.Errorf("resolve patterns: %s", strings.Join(errors, "; "))
-	}
-
-	return targets, nil
-}
-
-// listPackage is a minimal representation of go list -json output for a package.
-type listPackage struct {
-	ImportPath  string
-	Dir         string
-	ModulePath  string
-	ModuleDir   string
-	GoFiles     []string
-	TestGoFiles []string
-	XTestGoFiles []string
-	Error       struct {
-		ImportPath string
-		Pos        string
-		Err        string
-	}
+	return targets, errors, nil
 }

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -11,12 +11,12 @@ import (
 
 // Target represents a single Go package resolved from a pattern.
 type Target struct {
-	ImportPath string
 	Dir        string
+	ImportPath string
+	ModuleDir  string
+	ModulePath string
 	Files      []string
 	TestFiles  []string
-	ModulePath string
-	ModuleDir  string
 }
 
 type packageError struct {
@@ -27,14 +27,14 @@ type packageError struct {
 
 // listPackage is a minimal representation of go list -json output for a package.
 type listPackage struct {
-	ImportPath   string
+	Error        packageError
 	Dir          string
-	ModulePath   string
+	ImportPath   string
 	ModuleDir    string
+	ModulePath   string
 	GoFiles      []string
 	TestGoFiles  []string
 	XTestGoFiles []string
-	Error        packageError
 }
 
 type ResolverConfig struct {

--- a/internal/packages/packages_test.go
+++ b/internal/packages/packages_test.go
@@ -1,0 +1,312 @@
+package packages
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type getListFn func(*testing.T, *bytes.Buffer, error)
+
+var checkgetList = func(fns ...getListFn) []getListFn { return fns }
+
+func checkgetListError(want string) getListFn {
+	return func(t *testing.T, _ *bytes.Buffer, err error) {
+		t.Helper()
+		if want == "" {
+			assert.NoErrorf(t, err, "checkgetListError: expected no error, got %v", err)
+			return
+		}
+		if assert.Errorf(t, err, "checkgetListError: expected error %q", want) {
+			assert.Containsf(t, err.Error(), want, "checkgetListError mismatch")
+		}
+	}
+}
+
+func checkgetListBuffer(want string) getListFn {
+	return func(t *testing.T, buf *bytes.Buffer, err error) {
+		t.Helper()
+		assert.NotNil(t, buf, "buffer should not be nil")
+		assert.Contains(t, buf.String(), want, "getListBuffer mismatch")
+	}
+}
+
+func Test_getList(t *testing.T) {
+	tests := []struct {
+		name       string
+		patterns   []string
+		checks     []getListFn
+		newContext func() context.Context
+	}{
+		{
+			name: "empty_patterns",
+			checks: checkgetList(
+				checkgetListError(""),
+				checkgetListBuffer("ImportPath"),
+			),
+		},
+		{
+			name:     "dot_pattern",
+			patterns: []string{"."},
+			checks: checkgetList(
+				checkgetListError(""),
+				checkgetListBuffer("github.com/padiazg/go-crap/internal/packages"),
+			),
+		},
+		{
+			name:     "recursive_pattern",
+			patterns: []string{"./..."},
+			checks: checkgetList(
+				checkgetListError(""),
+				checkgetListBuffer("github.com/padiazg/go-crap/internal/packages"),
+			),
+		},
+		{
+			name:     "module_path_pattern",
+			patterns: []string{"github.com/padiazg/go-crap/internal/packages"},
+			checks: checkgetList(
+				checkgetListError(""),
+				checkgetListBuffer("github.com/padiazg/go-crap/internal/packages"),
+			),
+		},
+		{
+			name: "multiple_patterns",
+			patterns: []string{
+				"github.com/padiazg/go-crap/internal/packages",
+				"github.com/padiazg/go-crap/internal/score",
+			},
+			checks: checkgetList(
+				checkgetListError(""),
+				func(t *testing.T, buf *bytes.Buffer, err error) {
+					t.Helper()
+					require.NoError(t, err)
+					dec := json.NewDecoder(buf)
+					var paths []string
+					for dec.More() {
+						var pkg listPackage
+						err := dec.Decode(&pkg)
+						require.NoError(t, err, "unexpected decode error")
+						paths = append(paths, pkg.ImportPath)
+					}
+					require.Len(t, paths, 2, "expected exactly 2 packages")
+					assert.Contains(t, paths, "github.com/padiazg/go-crap/internal/packages")
+					assert.Contains(t, paths, "github.com/padiazg/go-crap/internal/score")
+				},
+			),
+		},
+		{
+			name:     "nonexistent_pattern",
+			patterns: []string{"./nonexistent/..."},
+			checks: checkgetList(
+				// -e embeds errors in JSON; getList defers to getTargets.
+				checkgetListError(""),
+				checkgetListBuffer("no such file or directory"),
+			),
+		},
+		{
+			name:     "malformed_pattern",
+			patterns: []string{"("},
+			checks: checkgetList(
+				checkgetListError(""),
+				checkgetListBuffer("malformed import path"),
+			),
+		},
+		{
+			name: "ctx_cancelled",
+			checks: checkgetList(
+				checkgetListError("context canceled"),
+			),
+			newContext: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.newContext != nil {
+				ctx = tt.newContext()
+			}
+			r, err := getList(ctx, tt.patterns)
+			for _, c := range tt.checks {
+				c(t, r, err)
+			}
+		})
+	}
+}
+
+type getTargetsFn func(*testing.T, []Target, []string, error)
+
+var checkgetTargets = func(fns ...getTargetsFn) []getTargetsFn { return fns }
+
+func checkgetTargetsError(want string) getTargetsFn {
+	return func(t *testing.T, _ []Target, _ []string, err error) {
+		t.Helper()
+		if want == "" {
+			assert.NoErrorf(t, err, "checkgetTargetsError: expected no error, got %v", err)
+			return
+		}
+		if assert.Errorf(t, err, "checkgetTargetsError: expected error %q", want) {
+			assert.Containsf(t, err.Error(), want, "checkgetTargetsError mismatch")
+		}
+	}
+}
+func Test_getTargets(t *testing.T) {
+	marshalJSON := func(v any) string {
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
+
+	pkgJSON := func(imp, dir, modPath, modDir string, goFiles, testGoFiles, xtestGoFiles []string, errStr string) string {
+		var errJSON string
+		if errStr == "" {
+			errJSON = "null"
+		} else {
+			b, _ := json.Marshal(packageError{Err: errStr})
+			errJSON = string(b)
+		}
+		return fmt.Sprintf(`{"ImportPath":%q,"Dir":%q,"ModulePath":%q,"ModuleDir":%q,"GoFiles":%s,"TestGoFiles":%s,"XTestGoFiles":%s,"Error":%s}`+"\n",
+			imp, dir, modPath, modDir,
+			marshalJSON(goFiles), marshalJSON(testGoFiles), marshalJSON(xtestGoFiles), errJSON)
+	}
+
+	tests := []struct {
+		name         string
+		stdout       *bytes.Buffer
+		includeTests bool
+		checks       []getTargetsFn
+	}{
+		{
+			name:   "empty_output",
+			stdout: bytes.NewBuffer(nil),
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.Empty(t, targets)
+					assert.Empty(t, errors)
+				},
+			),
+		},
+		{
+			name:   "single_valid_package_no_test_files",
+			stdout: bytes.NewBufferString(pkgJSON("github.com/padiazg/go-crap/internal/packages", "/go/src/github.com/padiazg/go-crap/internal/packages", "github.com/padiazg/go-crap", "/go/src/github.com/padiazg/go-crap", []string{"packages.go"}, nil, nil, "")),
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					require.Len(t, targets, 1)
+					assert.Equal(t, "github.com/padiazg/go-crap/internal/packages", targets[0].ImportPath)
+					assert.Equal(t, "/go/src/github.com/padiazg/go-crap/internal/packages", targets[0].Dir)
+					require.Len(t, targets[0].Files, 1)
+					assert.Contains(t, targets[0].Files[0], "internal/packages/packages.go")
+					assert.Empty(t, targets[0].TestFiles)
+				},
+				checkgetTargetsError(""),
+			),
+		},
+		{
+			name:         "single_valid_package_with_test_files",
+			stdout:       bytes.NewBufferString(pkgJSON("github.com/padiazg/go-crap/internal/packages", "/go/src/github.com/padiazg/go-crap/internal/packages", "github.com/padiazg/go-crap", "/go/src/github.com/padiazg/go-crap", []string{"packages.go"}, []string{"packages_test.go"}, []string{"packages_extra_test.go"}, "")),
+			includeTests: true,
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					require.Len(t, targets, 1)
+					require.Len(t, targets[0].TestFiles, 2)
+					assert.Contains(t, targets[0].TestFiles[0], "packages_test.go")
+					assert.Contains(t, targets[0].TestFiles[1], "packages_extra_test.go")
+				},
+				checkgetTargetsError(""),
+			),
+		},
+		{
+			name:   "single_package_with_error",
+			stdout: bytes.NewBufferString(pkgJSON("github.com/padiazg/go-crap/internal/bad", "/go/src/github.com/padiazg/go-crap/internal/bad", "github.com/padiazg/go-crap", "/go/src/github.com/padiazg/go-crap", nil, nil, nil, "cannot find module and listed as ./bad")),
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.Empty(t, targets)
+					require.Len(t, errors, 1)
+					assert.Contains(t, errors[0], "cannot find module")
+				},
+			),
+		},
+		{
+			name: "multiple_packages_mixed",
+			stdout: func() *bytes.Buffer {
+				var b bytes.Buffer
+				b.WriteString(pkgJSON("github.com/padiazg/go-crap/internal/packages", "/go/src/github.com/padiazg/go-crap/internal/packages", "github.com/padiazg/go-crap", "/go/src/github.com/padiazg/go-crap", []string{"packages.go"}, nil, nil, ""))
+				b.WriteString(pkgJSON("github.com/padiazg/go-crap/internal/bad", "/go/src/github.com/padiazg/go-crap/internal/bad", "github.com/padiazg/go-crap", "/go/src/github.com/padiazg/go-crap", nil, nil, nil, "build error"))
+				b.WriteString(pkgJSON("github.com/padiazg/go-crap/internal/score", "/go/src/github.com/padiazg/go-crap/internal/score", "github.com/padiazg/go-crap", "/go/src/github.com/padiazg/go-crap", []string{"score.go"}, nil, nil, ""))
+				return &b
+			}(),
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					require.Len(t, targets, 2)
+					assert.Equal(t, "github.com/padiazg/go-crap/internal/packages", targets[0].ImportPath)
+					assert.Equal(t, "github.com/padiazg/go-crap/internal/score", targets[1].ImportPath)
+					require.Len(t, errors, 1)
+					assert.Contains(t, errors[0], "build error")
+				},
+				checkgetTargetsError(""),
+			),
+		},
+		{
+			name:   "malformed_json",
+			stdout: bytes.NewBufferString(`{"ImportPath":`),
+			checks: checkgetTargets(
+				checkgetTargetsError("decode JSON"),
+			),
+		},
+		{
+			name:   "null_fields",
+			stdout: bytes.NewBufferString(`{"ImportPath":"example.com/pkg","Dir":"/go/src/example.com/pkg","GoFiles":null,"TestGoFiles":null,"XTestGoFiles":null}` + "\n"),
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					require.Len(t, targets, 1)
+					assert.Equal(t, "example.com/pkg", targets[0].ImportPath)
+					assert.Nil(t, targets[0].Files)
+					assert.Empty(t, targets[0].TestFiles)
+				},
+				checkgetTargetsError(""),
+			),
+		},
+		{
+			name:   "empty_import_path",
+			stdout: bytes.NewBufferString(`{"ImportPath":"","Dir":"","GoFiles":null}` + "\n"),
+			checks: checkgetTargets(
+				func(t *testing.T, targets []Target, errors []string, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					require.Len(t, targets, 1)
+					assert.Empty(t, targets[0].ImportPath)
+				},
+				checkgetTargetsError(""),
+			),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r, r2, err := getTargets(tt.stdout, tt.includeTests)
+			for _, c := range tt.checks {
+				c(t, r, r2, err)
+			}
+		})
+	}
+}

--- a/internal/packages/packages_test.go
+++ b/internal/packages/packages_test.go
@@ -11,139 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type getListFn func(*testing.T, *bytes.Buffer, error)
-
-var checkgetList = func(fns ...getListFn) []getListFn { return fns }
-
-func checkgetListError(want string) getListFn {
-	return func(t *testing.T, _ *bytes.Buffer, err error) {
-		t.Helper()
-		if want == "" {
-			assert.NoErrorf(t, err, "checkgetListError: expected no error, got %v", err)
-			return
-		}
-		if assert.Errorf(t, err, "checkgetListError: expected error %q", want) {
-			assert.Containsf(t, err.Error(), want, "checkgetListError mismatch")
-		}
-	}
-}
-
-func checkgetListBuffer(want string) getListFn {
-	return func(t *testing.T, buf *bytes.Buffer, err error) {
-		t.Helper()
-		assert.NotNil(t, buf, "buffer should not be nil")
-		assert.Contains(t, buf.String(), want, "getListBuffer mismatch")
-	}
-}
-
-func Test_getList(t *testing.T) {
-	tests := []struct {
-		name       string
-		patterns   []string
-		checks     []getListFn
-		newContext func() context.Context
-	}{
-		{
-			name: "empty_patterns",
-			checks: checkgetList(
-				checkgetListError(""),
-				checkgetListBuffer("ImportPath"),
-			),
-		},
-		{
-			name:     "dot_pattern",
-			patterns: []string{"."},
-			checks: checkgetList(
-				checkgetListError(""),
-				checkgetListBuffer("github.com/padiazg/go-crap/internal/packages"),
-			),
-		},
-		{
-			name:     "recursive_pattern",
-			patterns: []string{"./..."},
-			checks: checkgetList(
-				checkgetListError(""),
-				checkgetListBuffer("github.com/padiazg/go-crap/internal/packages"),
-			),
-		},
-		{
-			name:     "module_path_pattern",
-			patterns: []string{"github.com/padiazg/go-crap/internal/packages"},
-			checks: checkgetList(
-				checkgetListError(""),
-				checkgetListBuffer("github.com/padiazg/go-crap/internal/packages"),
-			),
-		},
-		{
-			name: "multiple_patterns",
-			patterns: []string{
-				"github.com/padiazg/go-crap/internal/packages",
-				"github.com/padiazg/go-crap/internal/score",
-			},
-			checks: checkgetList(
-				checkgetListError(""),
-				func(t *testing.T, buf *bytes.Buffer, err error) {
-					t.Helper()
-					require.NoError(t, err)
-					dec := json.NewDecoder(buf)
-					var paths []string
-					for dec.More() {
-						var pkg listPackage
-						err := dec.Decode(&pkg)
-						require.NoError(t, err, "unexpected decode error")
-						paths = append(paths, pkg.ImportPath)
-					}
-					require.Len(t, paths, 2, "expected exactly 2 packages")
-					assert.Contains(t, paths, "github.com/padiazg/go-crap/internal/packages")
-					assert.Contains(t, paths, "github.com/padiazg/go-crap/internal/score")
-				},
-			),
-		},
-		{
-			name:     "nonexistent_pattern",
-			patterns: []string{"./nonexistent/..."},
-			checks: checkgetList(
-				// -e embeds errors in JSON; getList defers to getTargets.
-				checkgetListError(""),
-				checkgetListBuffer("no such file or directory"),
-			),
-		},
-		{
-			name:     "malformed_pattern",
-			patterns: []string{"("},
-			checks: checkgetList(
-				checkgetListError(""),
-				checkgetListBuffer("malformed import path"),
-			),
-		},
-		{
-			name: "ctx_cancelled",
-			checks: checkgetList(
-				checkgetListError("context canceled"),
-			),
-			newContext: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				return ctx
-			},
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			if tt.newContext != nil {
-				ctx = tt.newContext()
-			}
-			r, err := getList(ctx, tt.patterns)
-			for _, c := range tt.checks {
-				c(t, r, err)
-			}
-		})
-	}
-}
-
 type getTargetsFn func(*testing.T, []Target, []string, error)
+
+// fakeGoListRunner is a test double for GoListRunner.
+type fakeGoListRunner struct {
+	Output   []byte
+	Err      error
+	Patterns []string
+}
+
+func (f *fakeGoListRunner) List(ctx context.Context, patterns []string) ([]byte, error) {
+	f.Patterns = patterns
+	return f.Output, f.Err
+}
 
 var checkgetTargets = func(fns ...getTargetsFn) []getTargetsFn { return fns }
 
@@ -159,6 +39,24 @@ func checkgetTargetsError(want string) getTargetsFn {
 		}
 	}
 }
+
+func Test_NewGoListRunner(t *testing.T) {
+	r := NewGoListRunner()
+	assert.NotNil(t, r)
+	_, ok := r.(*goListRunner)
+	assert.True(t, ok, "NewGoListRunner should return *goListRunner")
+
+	r2 := NewGoListRunnerWithDir("/custom/dir")
+	gr, ok := r2.(*goListRunner)
+	assert.True(t, ok)
+	assert.Equal(t, "/custom/dir", gr.dir)
+}
+
+func Test_WithEnv(t *testing.T) {
+	r := WithEnv([]string{"GO111MODULE=off", "FOO=bar"}).(*goListRunner)
+	assert.Equal(t, []string{"GO111MODULE=off", "FOO=bar"}, r.env)
+}
+
 func Test_getTargets(t *testing.T) {
 	marshalJSON := func(v any) string {
 		b, _ := json.Marshal(v)
@@ -306,6 +204,303 @@ func Test_getTargets(t *testing.T) {
 			r, r2, err := getTargets(tt.stdout, tt.includeTests)
 			for _, c := range tt.checks {
 				c(t, r, r2, err)
+			}
+		})
+	}
+}
+
+type NewResolverFn func(*testing.T, *Resolver)
+
+var checkNewResolver = func(fns ...NewResolverFn) []NewResolverFn { return fns }
+
+func TestNewResolver(t *testing.T) {
+	sampleJSON := `{"ImportPath":"example.com/pkg","Dir":"/go/src/example.com/pkg","GoFiles":["a.go"]}` + "\n"
+
+	fakeRunner := &fakeGoListRunner{Output: []byte(sampleJSON)}
+	dirRunner := NewGoListRunnerWithDir("/custom/dir")
+
+	checkDefaults := func(t *testing.T, r *Resolver) {
+		t.Helper()
+		require.NotNil(t, r)
+		require.IsType(t, &goListRunner{}, r.runner)
+		gr := r.runner.(*goListRunner)
+		assert.Equal(t, ".", gr.dir)
+		assert.Contains(t, gr.env, "GO111MODULE=on")
+	}
+
+	checkSame := func(want GoListRunner) NewResolverFn {
+		return func(t *testing.T, r *Resolver) {
+			t.Helper()
+			require.NotNil(t, r)
+			assert.Same(t, want, r.runner)
+		}
+	}
+
+	// checkOutput := func() NewResolverFn {
+	// 	return func(t *testing.T, r *Resolver) {
+	// 		t.Helper()
+	// 		targets, err := r.Resolve(context.Background(), []string{"example.com/..."}, false)
+	// 		require.NoError(t, err)
+	// 		require.Len(t, targets, 1)
+	// 		assert.Equal(t, "example.com/pkg", targets[0].ImportPath)
+	// 	}
+	// }
+
+	// checkError := func() NewResolverFn {
+	// 	return func(t *testing.T, r *Resolver) {
+	// 		t.Helper()
+	// 		_, err := r.Resolve(context.Background(), []string{"."}, false)
+	// 		assert.EqualError(t, err, "boom")
+	// 	}
+	// }
+
+	tests := []struct {
+		name   string
+		config *ResolverConfig
+		checks []NewResolverFn
+	}{
+		{
+			name:   "nil_config_uses_default_runner",
+			config: nil,
+			checks: checkNewResolver(checkDefaults),
+		},
+		{
+			name:   "empty_config_uses_default_runner",
+			config: &ResolverConfig{},
+			checks: checkNewResolver(checkDefaults),
+		},
+		{
+			name:   "nil_runner_uses_default_runner",
+			config: &ResolverConfig{Runner: nil},
+			checks: checkNewResolver(checkDefaults),
+		},
+		{
+			name:   "custom_runner_kept",
+			config: &ResolverConfig{Runner: fakeRunner},
+			checks: checkNewResolver(checkSame(fakeRunner)),
+		},
+		{
+			name:   "custom_runner_with_dir_kept",
+			config: &ResolverConfig{Runner: dirRunner},
+			checks: checkNewResolver(
+				checkSame(dirRunner),
+				func(t *testing.T, r *Resolver) {
+					t.Helper()
+					gr := r.runner.(*goListRunner)
+					assert.Equal(t, "/custom/dir", gr.dir)
+				},
+			),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewResolver(tt.config)
+			for _, c := range tt.checks {
+				c(t, r)
+			}
+		})
+	}
+}
+
+type checkResolverResolveFn func(*testing.T, []Target, error)
+
+var checkResolverResolve = func(fns ...checkResolverResolveFn) []checkResolverResolveFn { return fns }
+
+var capturedRunner *fakeGoListRunner
+
+func checkResolveError(want string) checkResolverResolveFn {
+	return func(t *testing.T, _ []Target, err error) {
+		t.Helper()
+		if want == "" {
+			assert.NoErrorf(t, err, "checkResolveError: expected no error, got %v", err)
+			return
+		}
+		if assert.Errorf(t, err, "checkResolveError: expected error %q", want) {
+			assert.Containsf(t, err.Error(), want, "checkResolveError mismatch")
+		}
+	}
+}
+func TestResolver_Resolve(t *testing.T) {
+	marshalJSON := func(v any) string {
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
+
+	pkgJSON := func(imp, dir, modPath, modDir string, goFiles, testGoFiles, xtestGoFiles []string, errStr string) string {
+		var errJSON string
+		if errStr == "" {
+			errJSON = "null"
+		} else {
+			b, _ := json.Marshal(packageError{Err: errStr})
+			errJSON = string(b)
+		}
+		return fmt.Sprintf(`{"ImportPath":%q,"Dir":%q,"ModulePath":%q,"ModuleDir":%q,"GoFiles":%s,"TestGoFiles":%s,"XTestGoFiles":%s,"Error":%s}`+"\n",
+			imp, dir, modPath, modDir,
+			marshalJSON(goFiles), marshalJSON(testGoFiles), marshalJSON(xtestGoFiles), errJSON)
+	}
+
+	singlePkg := pkgJSON(
+		"github.com/padiazg/go-crap/internal/packages",
+		"/go/src/github.com/padiazg/go-crap/internal/packages",
+		"github.com/padiazg/go-crap",
+		"/go/src/github.com/padiazg/go-crap",
+		[]string{"packages.go"},
+		nil,
+		nil,
+		"",
+	)
+
+	singlePkgWithTests := pkgJSON(
+		"github.com/padiazg/go-crap/internal/packages",
+		"/go/src/github.com/padiazg/go-crap/internal/packages",
+		"github.com/padiazg/go-crap",
+		"/go/src/github.com/padiazg/go-crap",
+		[]string{"packages.go"},
+		[]string{"packages_test.go"},
+		[]string{"packages_extra_test.go"},
+		"",
+	)
+
+	badPkg := pkgJSON(
+		"github.com/padiazg/go-crap/internal/bad",
+		"/go/src/github.com/padiazg/go-crap/internal/bad",
+		"github.com/padiazg/go-crap",
+		"/go/src/github.com/padiazg/go-crap",
+		nil,
+		nil,
+		nil,
+		"cannot find module",
+	)
+
+	tests := []struct {
+		name         string
+		patterns     []string
+		includeTests bool
+		checks       []checkResolverResolveFn
+		before       func(*Resolver)
+	}{
+		{
+			name:     "resolves_single_package",
+			patterns: []string{"github.com/padiazg/go-crap/..."},
+			before:   func(s *Resolver) { s.runner = &fakeGoListRunner{Output: []byte(singlePkg)} },
+			checks: checkResolverResolve(
+				func(t *testing.T, targets []Target, err error) {
+					t.Helper()
+					require.NoError(t, err)
+					require.Len(t, targets, 1)
+					assert.Equal(t, "github.com/padiazg/go-crap/internal/packages", targets[0].ImportPath)
+					assert.Equal(t, "/go/src/github.com/padiazg/go-crap/internal/packages", targets[0].Dir)
+					require.Len(t, targets[0].Files, 1)
+					assert.Equal(t, "/go/src/github.com/padiazg/go-crap/internal/packages/packages.go", targets[0].Files[0])
+				},
+				checkResolveError(""),
+			),
+		},
+		{
+			name:     "propagates_runner_error",
+			patterns: []string{"./..."},
+			before:   func(s *Resolver) { s.runner = &fakeGoListRunner{Err: fmt.Errorf("boom")} },
+			checks: checkResolverResolve(
+				checkResolveError("boom"),
+			),
+		},
+		{
+			name:     "empty_output_returns_empty",
+			patterns: []string{"./..."},
+			before:   func(s *Resolver) { s.runner = &fakeGoListRunner{Output: nil} },
+			checks: checkResolverResolve(
+				func(t *testing.T, targets []Target, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.Empty(t, targets)
+				},
+				checkResolveError(""),
+			),
+		},
+		{
+			name:     "malformed_json_returns_decode_error",
+			patterns: []string{"./..."},
+			before:   func(s *Resolver) { s.runner = &fakeGoListRunner{Output: []byte(`{"ImportPath":`)} },
+			checks: checkResolverResolve(
+				checkResolveError("decode JSON"),
+			),
+		},
+		{
+			name:     "all_packages_error_returns_joined_error",
+			patterns: []string{"./..."},
+			before:   func(s *Resolver) { s.runner = &fakeGoListRunner{Output: []byte(badPkg)} },
+			checks: checkResolverResolve(
+				checkResolveError("resolve patterns"),
+			),
+		},
+		{
+			name:     "mixed_valid_and_error_returns_targets",
+			patterns: []string{"./..."},
+			before: func(s *Resolver) {
+				var buf bytes.Buffer
+				buf.WriteString(singlePkg)
+				buf.WriteString(badPkg)
+				s.runner = &fakeGoListRunner{Output: buf.Bytes()}
+			},
+			checks: checkResolverResolve(
+				func(t *testing.T, targets []Target, err error) {
+					t.Helper()
+					require.NoError(t, err)
+					require.Len(t, targets, 1)
+					assert.Equal(t, "github.com/padiazg/go-crap/internal/packages", targets[0].ImportPath)
+				},
+				checkResolveError(""),
+			),
+		},
+		{
+			name:         "include_tests_collects_test_files",
+			patterns:     []string{"./..."},
+			includeTests: true,
+			before:       func(s *Resolver) { s.runner = &fakeGoListRunner{Output: []byte(singlePkgWithTests)} },
+			checks: checkResolverResolve(
+				func(t *testing.T, targets []Target, err error) {
+					t.Helper()
+					require.NoError(t, err)
+					require.Len(t, targets, 1)
+					require.Len(t, targets[0].TestFiles, 2)
+					assert.Contains(t, targets[0].TestFiles[0], "packages_test.go")
+					assert.Contains(t, targets[0].TestFiles[1], "packages_extra_test.go")
+				},
+				checkResolveError(""),
+			),
+		},
+		{
+			name:     "patterns_passed_to_runner",
+			patterns: []string{"github.com/padiazg/go-crap/internal/...", "./..."},
+			before: func(s *Resolver) {
+				fake := &fakeGoListRunner{Output: []byte(singlePkg)}
+				s.runner = fake
+				capturedRunner = fake
+			},
+			checks: checkResolverResolve(
+				func(t *testing.T, targets []Target, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					require.Len(t, capturedRunner.Patterns, 2)
+					assert.Equal(t, "github.com/padiazg/go-crap/internal/...", capturedRunner.Patterns[0])
+					assert.Equal(t, "./...", capturedRunner.Patterns[1])
+				},
+				checkResolveError(""),
+			),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			capturedRunner = nil
+			s := NewResolver(nil)
+			if tt.before != nil {
+				tt.before(s)
+			}
+			r, err := s.Resolve(context.Background(), tt.patterns, tt.includeTests)
+			for _, c := range tt.checks {
+				c(t, r, err)
 			}
 		})
 	}

--- a/internal/packages/runner.go
+++ b/internal/packages/runner.go
@@ -1,0 +1,64 @@
+package packages
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// GoListRunner runs `go list -json -e` and returns stdout bytes.
+type GoListRunner interface {
+	List(ctx context.Context, patterns []string) ([]byte, error)
+}
+
+// goListRunner is the default real implementation.
+type goListRunner struct {
+	dir string // working directory
+	env []string // environment
+}
+
+// NewGoListRunner returns a GoListRunner with defaults:
+//
+//	dir = "."
+//	env = os.Environ() + "GO111MODULE=on"
+func NewGoListRunner() GoListRunner {
+	return &goListRunner{
+		dir: ".",
+		env: append(os.Environ(), "GO111MODULE=on"),
+	}
+}
+
+// NewGoListRunnerWithDir returns a runner that uses the given working directory.
+func NewGoListRunnerWithDir(dir string) GoListRunner {
+	r := NewGoListRunner().(*goListRunner)
+	r.dir = dir
+	return r
+}
+
+// WithEnv sets the environment for the runner.
+// If called multiple times, the last call wins.
+func WithEnv(env []string) GoListRunner {
+	r := NewGoListRunner().(*goListRunner)
+	r.env = env
+	return r
+}
+
+func (r *goListRunner) List(ctx context.Context, patterns []string) ([]byte, error) {
+	args := []string{"list", "-e", "-json"}
+	args = append(args, patterns...)
+
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = r.dir
+	cmd.Env = r.env
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+
+	err := cmd.Run()
+	if err != nil && stdout.Len() == 0 {
+		return nil, err
+	}
+
+	return stdout.Bytes(), nil
+}

--- a/internal/packages/runner.go
+++ b/internal/packages/runner.go
@@ -14,7 +14,7 @@ type GoListRunner interface {
 
 // goListRunner is the default real implementation.
 type goListRunner struct {
-	dir string // working directory
+	dir string   // working directory
 	env []string // environment
 }
 

--- a/internal/packages/runner_test.go
+++ b/internal/packages/runner_test.go
@@ -1,0 +1,134 @@
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"context"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type checkgoListRunnerListFn func(*testing.T, []byte, error)
+
+var checkgoListRunnerList = func(fns ...checkgoListRunnerListFn) []checkgoListRunnerListFn { return fns }
+
+func checkListError(want string) checkgoListRunnerListFn {
+	return func(t *testing.T, _ []byte, err error) {
+		t.Helper()
+		if want == "" {
+			assert.NoErrorf(t, err, "checkListError: expected no error, got %v", err)
+			return
+		}
+		if assert.Errorf(t, err, "checkListError: expected error %q", want) {
+			assert.Containsf(t, err.Error(), want, "checkListError mismatch")
+		}
+	}
+}
+func Test_goListRunner_List(t *testing.T) {
+	checkOutputContains := func(want string) checkgoListRunnerListFn {
+		return func(t *testing.T, got []byte, err error) {
+			t.Helper()
+			assert.Containsf(t, string(got), want, "output should contain %q", want)
+		}
+	}
+
+	writeFixtureModule := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/fixture\n\ngo 1.26\n"), 0644)
+		os.WriteFile(filepath.Join(dir, "root.go"), []byte("package fixture\n\nfunc Root() int { return 1 }\n"), 0644)
+		os.MkdirAll(filepath.Join(dir, "sub"), 0755)
+		os.WriteFile(filepath.Join(dir, "sub", "sub.go"), []byte("package sub\n\nfunc Sub() int { return 2 }\n"), 0644)
+		return dir
+	}
+
+	tests := []struct {
+		name        string
+		patterns    []string
+		checks      []checkgoListRunnerListFn
+		before      func(*goListRunner)
+		newContext  func() context.Context
+	}{
+		{
+			name:     "success_lists_single_package",
+			patterns: []string{"."},
+			before:   func(s *goListRunner) { s.dir = writeFixtureModule(t) },
+			checks: checkgoListRunnerList(
+				checkListError(""),
+				checkOutputContains(`"ImportPath":`),
+				checkOutputContains(`"example.com/fixture"`),
+			),
+		},
+		{
+			name:     "wildcard_lists_all_packages",
+			patterns: []string{"./..."},
+			before:   func(s *goListRunner) { s.dir = writeFixtureModule(t) },
+			checks: checkgoListRunnerList(
+				checkListError(""),
+				checkOutputContains(`"example.com/fixture/sub"`),
+			),
+		},
+		{
+			name:     "pattern_filters_package_set",
+			patterns: []string{"./sub"},
+			before:   func(s *goListRunner) { s.dir = writeFixtureModule(t) },
+			checks: checkgoListRunnerList(
+				checkListError(""),
+				func(t *testing.T, got []byte, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.Contains(t, string(got), `"example.com/fixture/sub"`)
+					assert.Equal(t, 1, strings.Count(string(got), `"ImportPath":`), "expected exactly one ImportPath")
+				},
+			),
+		},
+		{
+			name:     "tolerant_of_missing_pattern",
+			patterns: []string{"./nope"},
+			before:   func(s *goListRunner) { s.dir = writeFixtureModule(t) },
+			checks: checkgoListRunnerList(
+				checkListError(""),
+				checkOutputContains(`"Error":`),
+			),
+		},
+		{
+			name:     "nonexistent_directory_returns_error",
+			patterns: []string{"."},
+			before: func(s *goListRunner) {
+				s.dir = filepath.Join(t.TempDir(), "nope")
+			},
+			checks: checkgoListRunnerList(
+				checkListError("no such file or directory"),
+			),
+		},
+		{
+			name:       "canceled_context_returns_error",
+			patterns:   []string{"."},
+			before:     func(s *goListRunner) { s.dir = writeFixtureModule(t) },
+			newContext: func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx },
+			checks: checkgoListRunnerList(
+				checkListError("context canceled"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			s := &goListRunner{}
+			if tt.before != nil {
+				tt.before(s)
+			}
+			ctx := context.Background()
+			if tt.newContext != nil {
+				ctx = tt.newContext()
+			}
+			r, err := s.List(ctx, tt.patterns)
+			for _, c := range tt.checks {
+				c(t, r, err)
+			}
+		})
+	}
+}

--- a/internal/packages/runner_test.go
+++ b/internal/packages/runner_test.go
@@ -46,11 +46,11 @@ func Test_goListRunner_List(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		patterns    []string
-		checks      []checkgoListRunnerListFn
-		before      func(*goListRunner)
-		newContext  func() context.Context
+		name       string
+		patterns   []string
+		checks     []checkgoListRunnerListFn
+		before     func(*goListRunner)
+		newContext func() context.Context
 	}{
 		{
 			name:     "success_lists_single_package",

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -105,71 +105,122 @@ func Scan(options *Options) (*Entries, error) {
 	return entries, err
 }
 
+// func runCoverageAnalysis(ctx context.Context, options *Options, patterns []string, exclude *regexp.Regexp, timeout time.Duration) ([]coverage.ModuleCoverage, error) {
+// 	scanner := coverage.NewScanner(".", exclude, options.Logger, timeout)
+// 	scanner.Profile = options.CoverageProfile
+// 	scanner.Progress = options.ProgressReporter
+
+// 	// If a profile is provided, fall back to path-based discovery (no go list needed).
+// 	if scanner.Profile != "" {
+// 		coverages, err := scanner.Scan(ctx)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("coverage scan: %w", err)
+// 		}
+// 		return coverages, nil
+// 	}
+
+// 	// Try to resolve patterns via go list. On failure, fall back to Path-based discovery.
+// 	if len(patterns) == 0 && options.Path != "" {
+// 		patterns = []string{options.Path}
+// 	}
+
+// 	targets, resolveErr := packages.Resolve(ctx, patterns, options.IncludeTests)
+// 	if resolveErr == nil && len(targets) > 0 {
+// 		// Group targets by module dir.
+// 		mt := groupTargets(targets)
+// 		scanner.Targets = mt
+
+// 		coverages, err := scanner.Scan(ctx)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("coverage scan: %w", err)
+// 		}
+// 		return coverages, nil
+// 	}
+
+// 	// Fallback to Path-based discovery (e.g. nested module dirs outside go list reach).
+// 	if options.Path != "" {
+// 		scanner.Path = options.Path
+// 		coverages, err := scanner.Scan(ctx)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("coverage scan: %w", err)
+// 		}
+// 		return coverages, nil
+// 	}
+
+// 	return nil, fmt.Errorf("coverage scan: resolve patterns: %w", resolveErr)
+// }
+
 func runCoverageAnalysis(ctx context.Context, options *Options, patterns []string, exclude *regexp.Regexp, timeout time.Duration) ([]coverage.ModuleCoverage, error) {
 	scanner := coverage.NewScanner(".", exclude, options.Logger, timeout)
 	scanner.Profile = options.CoverageProfile
 	scanner.Progress = options.ProgressReporter
 
-	// If a profile is provided, fall back to path-based discovery (no go list needed).
-	if scanner.Profile != "" {
-		coverages, err := scanner.Scan(ctx)
+	wrapError := func(fn func(ctx context.Context) ([]coverage.ModuleCoverage, error)) ([]coverage.ModuleCoverage, error) {
+		coverages, err := fn(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("coverage scan: %w", err)
 		}
+
 		return coverages, nil
+	}
+
+	// If a profile is provided, fall back to path-based discovery (no go list needed).
+	if scanner.Profile != "" {
+		return wrapError(scanner.Scan)
 	}
 
 	// Try to resolve patterns via go list. On failure, fall back to Path-based discovery.
 	if len(patterns) == 0 && options.Path != "" {
 		patterns = []string{options.Path}
 	}
-	targets, resolveErr := packages.Resolve(ctx, patterns, options.IncludeTests)
+
+	resolver := packages.NewResolver(nil)
+	targets, resolveErr := resolver.Resolve(ctx, patterns, options.IncludeTests)
 	if resolveErr == nil && len(targets) > 0 {
 		// Group targets by module dir.
-		modTargets := make(map[string]*coverage.ModuleTarget)
-		for _, t := range targets {
-			if t.ModuleDir == "" {
-				continue
-			}
-			relDir := t.Dir
-			if mtd, ok := modTargets[t.ModuleDir]; ok {
-				mtd.PkgDirs = append(mtd.PkgDirs, relDir)
-			} else {
-				modTargets[t.ModuleDir] = &coverage.ModuleTarget{
-					ModDir:  t.ModuleDir,
-					PkgDirs: []string{relDir},
-				}
-			}
-		}
-
-		var mt []coverage.ModuleTarget
-		for _, t := range modTargets {
-			mt = append(mt, *t)
-		}
+		mt := groupTargets(targets)
 		scanner.Targets = mt
 
-		coverages, err := scanner.Scan(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("coverage scan: %w", err)
-		}
-		return coverages, nil
+		return wrapError(scanner.Scan)
 	}
 
 	// Fallback to Path-based discovery (e.g. nested module dirs outside go list reach).
 	if options.Path != "" {
 		scanner.Path = options.Path
-		coverages, err := scanner.Scan(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("coverage scan: %w", err)
-		}
-		return coverages, nil
+		return wrapError(scanner.Scan)
 	}
 
 	return nil, fmt.Errorf("coverage scan: resolve patterns: %w", resolveErr)
 }
 
+func groupTargets(targets []packages.Target) []coverage.ModuleTarget {
+	modTargets := make(map[string]*coverage.ModuleTarget)
+	for _, t := range targets {
+		if t.ModuleDir == "" {
+			continue
+		}
+		relDir := t.Dir
+		if mtd, ok := modTargets[t.ModuleDir]; ok {
+			mtd.PkgDirs = append(mtd.PkgDirs, relDir)
+		} else {
+			modTargets[t.ModuleDir] = &coverage.ModuleTarget{
+				ModDir:  t.ModuleDir,
+				PkgDirs: []string{relDir},
+			}
+		}
+	}
+
+	var mt []coverage.ModuleTarget
+	for _, t := range modTargets {
+		mt = append(mt, *t)
+	}
+
+	return mt
+}
+
 func runComplexityAnalysis(_ context.Context, options *Options, patterns []string, exclude *regexp.Regexp) []complexity.Stat {
-	targets, err := packages.Resolve(context.Background(), patterns, options.IncludeTests)
+	resolver := packages.NewResolver(nil)
+	targets, err := resolver.Resolve(context.Background(), patterns, options.IncludeTests)
 	if err != nil {
 		// Fallback: if resolve fails (e.g. outside a module), fall back to Path-based walk.
 		if options.Path != "" {
@@ -182,10 +233,6 @@ func runComplexityAnalysis(_ context.Context, options *Options, patterns []strin
 	for _, t := range targets {
 		files = append(files, t.Files...)
 		files = append(files, t.TestFiles...)
-	}
-
-	if len(files) == 0 {
-		return nil
 	}
 
 	return complexity.AnalyzeFiles(files, exclude, options.Logger)

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/padiazg/go-crap/internal/complexity"
 	"github.com/padiazg/go-crap/internal/coverage"
 	"github.com/padiazg/go-crap/internal/merge"
+	"github.com/padiazg/go-crap/internal/packages"
 	"github.com/padiazg/go-crap/internal/score"
 	"github.com/padiazg/go-crap/pkg/logger"
 	pkgprogress "github.com/padiazg/go-crap/pkg/progress"
@@ -31,6 +32,7 @@ type Options struct {
 	Missing          string
 	MutationReport   string
 	Path             string
+	Patterns         []string
 	Exclude          []string
 	Min              float64
 	Timeout          time.Duration
@@ -67,8 +69,18 @@ func Scan(options *Options) (*Entries, error) {
 	defer pr.Done()
 	defer pr.Errored()
 
+	// Resolve patterns or fall back to path-based discovery.
+	patterns := options.Patterns
+	if len(patterns) == 0 && options.Path != "" {
+		// Back-compat: if Patterns not set but Path is, treat Path as a single pattern.
+		patterns = []string{options.Path}
+	}
+	if len(patterns) == 0 {
+		patterns = []string{"./..."}
+	}
+
 	pr.StartPhase(pkgprogress.PhaseCoverageTests, 0)
-	coverages, err := runCoverageAnalysis(ctx, options, exclude, timeout)
+	coverages, err := runCoverageAnalysis(ctx, options, patterns, exclude, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +89,7 @@ func Scan(options *Options) (*Entries, error) {
 	logCoverageErrors(options.Logger, coverages)
 
 	pr.StartPhase(pkgprogress.PhaseComplexity, 0)
-	stats := complexity.Analyze([]string{options.Path}, exclude, options.Logger)
+	stats := runComplexityAnalysis(ctx, options, patterns, exclude)
 	pr.FinishPhase()
 
 	pr.StartPhase(pkgprogress.PhaseProcessing, 0)
@@ -93,15 +105,90 @@ func Scan(options *Options) (*Entries, error) {
 	return entries, err
 }
 
-func runCoverageAnalysis(ctx context.Context, options *Options, exclude *regexp.Regexp, timeout time.Duration) ([]coverage.ModuleCoverage, error) {
-	scanner := coverage.NewScanner(options.Path, exclude, options.Logger, timeout)
+func runCoverageAnalysis(ctx context.Context, options *Options, patterns []string, exclude *regexp.Regexp, timeout time.Duration) ([]coverage.ModuleCoverage, error) {
+	scanner := coverage.NewScanner(".", exclude, options.Logger, timeout)
 	scanner.Profile = options.CoverageProfile
 	scanner.Progress = options.ProgressReporter
-	coverages, err := scanner.Scan(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("coverage scan: %w", err)
+
+	// If a profile is provided, fall back to path-based discovery (no go list needed).
+	if scanner.Profile != "" {
+		coverages, err := scanner.Scan(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("coverage scan: %w", err)
+		}
+		return coverages, nil
 	}
-	return coverages, nil
+
+	// Try to resolve patterns via go list. On failure, fall back to Path-based discovery.
+	if len(patterns) == 0 && options.Path != "" {
+		patterns = []string{options.Path}
+	}
+	targets, resolveErr := packages.Resolve(ctx, patterns, options.IncludeTests)
+	if resolveErr == nil && len(targets) > 0 {
+		// Group targets by module dir.
+		modTargets := make(map[string]*coverage.ModuleTarget)
+		for _, t := range targets {
+			if t.ModuleDir == "" {
+				continue
+			}
+			relDir := t.Dir
+			if mtd, ok := modTargets[t.ModuleDir]; ok {
+				mtd.PkgDirs = append(mtd.PkgDirs, relDir)
+			} else {
+				modTargets[t.ModuleDir] = &coverage.ModuleTarget{
+					ModDir:  t.ModuleDir,
+					PkgDirs: []string{relDir},
+				}
+			}
+		}
+
+		var mt []coverage.ModuleTarget
+		for _, t := range modTargets {
+			mt = append(mt, *t)
+		}
+		scanner.Targets = mt
+
+		coverages, err := scanner.Scan(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("coverage scan: %w", err)
+		}
+		return coverages, nil
+	}
+
+	// Fallback to Path-based discovery (e.g. nested module dirs outside go list reach).
+	if options.Path != "" {
+		scanner.Path = options.Path
+		coverages, err := scanner.Scan(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("coverage scan: %w", err)
+		}
+		return coverages, nil
+	}
+
+	return nil, fmt.Errorf("coverage scan: resolve patterns: %w", resolveErr)
+}
+
+func runComplexityAnalysis(_ context.Context, options *Options, patterns []string, exclude *regexp.Regexp) []complexity.Stat {
+	targets, err := packages.Resolve(context.Background(), patterns, options.IncludeTests)
+	if err != nil {
+		// Fallback: if resolve fails (e.g. outside a module), fall back to Path-based walk.
+		if options.Path != "" {
+			return complexity.Analyze([]string{options.Path}, exclude, options.Logger)
+		}
+		return nil
+	}
+
+	var files []string
+	for _, t := range targets {
+		files = append(files, t.Files...)
+		files = append(files, t.TestFiles...)
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+
+	return complexity.AnalyzeFiles(files, exclude, options.Logger)
 }
 
 func logCoverageErrors(l logger.Logger, coverages []coverage.ModuleCoverage) {

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -1055,7 +1055,7 @@ func Test_runComplexityAnalysis(t *testing.T) {
 		checks   []runComplexityAnalysisFn
 	}{
 		{
-			name:   "resolve_success_returns_stats",
+			name: "resolve_success_returns_stats",
 			options: &Options{
 				IncludeTests: false,
 			},
@@ -1068,7 +1068,7 @@ func Test_runComplexityAnalysis(t *testing.T) {
 			),
 		},
 		{
-			name:   "include_tests_true_appends_test_stats",
+			name: "include_tests_true_appends_test_stats",
 			options: &Options{
 				IncludeTests: true,
 			},
@@ -1080,7 +1080,7 @@ func Test_runComplexityAnalysis(t *testing.T) {
 			),
 		},
 		{
-			name:    "exclude_pattern_filters_functions",
+			name: "exclude_pattern_filters_functions",
 			options: &Options{
 				IncludeTests: false,
 			},
@@ -1093,7 +1093,7 @@ func Test_runComplexityAnalysis(t *testing.T) {
 			),
 		},
 		{
-			name:    "exclude_test_files_filters_file_paths",
+			name: "exclude_test_files_filters_file_paths",
 			options: &Options{
 				IncludeTests: true,
 			},
@@ -1106,7 +1106,7 @@ func Test_runComplexityAnalysis(t *testing.T) {
 			),
 		},
 		{
-			name:   "resolve_error_path_fallback_walks_directory",
+			name: "resolve_error_path_fallback_walks_directory",
 			options: &Options{
 				IncludeTests: true,
 				Path:         "../testdata",
@@ -1123,7 +1123,7 @@ func Test_runComplexityAnalysis(t *testing.T) {
 			),
 		},
 		{
-			name:    "path_fallback_excludes_test_files",
+			name: "path_fallback_excludes_test_files",
 			options: &Options{
 				IncludeTests: true,
 				Path:         "../testdata",
@@ -1138,12 +1138,12 @@ func Test_runComplexityAnalysis(t *testing.T) {
 			),
 		},
 		{
-			name:   "resolve_error_without_path_returns_empty",
+			name: "resolve_error_without_path_returns_empty",
 			options: &Options{
 				IncludeTests: false,
 			},
 			patterns: []string{"../nonexistent/..."},
-			checks: checkrunComplexityAnalysis(checkComplexityEmpty()),
+			checks:   checkrunComplexityAnalysis(checkComplexityEmpty()),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -411,7 +411,7 @@ func Test_runCoverageAnalysis(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			r, err := runCoverageAnalysis(context.Background(), tt.options, tt.exclude, 0)
+			r, err := runCoverageAnalysis(context.Background(), tt.options, tt.options.Patterns, tt.exclude, 0)
 			for _, c := range tt.checks {
 				c(t, r, err)
 			}

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -8,12 +8,15 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/padiazg/go-crap/internal/complexity"
 	"github.com/padiazg/go-crap/internal/coverage"
+	"github.com/padiazg/go-crap/internal/packages"
 	"github.com/padiazg/go-crap/internal/score"
 	"github.com/padiazg/go-crap/pkg/logger"
 	"github.com/padiazg/go-crap/pkg/utils"
@@ -335,6 +338,45 @@ func TestScan(t *testing.T) {
 	}
 }
 
+func TestScan_fallbackToDotSlashSlash(t *testing.T) {
+	dir, err := os.MkdirTemp("", "scan-dot-slash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+
+	for _, f := range []string{"complex.go", "cover.out", "simple.go", "simple_test.go", "go.mod"} {
+		src, err := os.ReadFile(filepath.Join("../testdata", f))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, f), src, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Neither Patterns nor Path is set → line 78 triggers: patterns = ["./..."]
+	r, err := Scan(&Options{
+		IncludeTests: true,
+	})
+	if err != nil {
+		t.Fatalf("Scan with empty options failed (line 78 fallback): %v", err)
+	}
+	if len(r.List) == 0 {
+		t.Fatal("expected non-empty result from ./... fallback")
+	}
+}
+
 func Test_resolveTimeout(t *testing.T) {
 	tests := []struct {
 		name string
@@ -355,17 +397,19 @@ func Test_resolveTimeout(t *testing.T) {
 // Test_runCoverageAnalysis exercises the coverage scanner pipeline.
 func Test_runCoverageAnalysis(t *testing.T) {
 	tests := []struct {
-		name    string
-		options *Options
-		exclude *regexp.Regexp
-		checks  []func(*testing.T, []coverage.ModuleCoverage, error)
+		name     string
+		options  *Options
+		patterns []string
+		exclude  *regexp.Regexp
+		checks   []func(*testing.T, []coverage.ModuleCoverage, error)
 	}{
 		{
 			name: "valid_path_returns_coverage_data",
 			options: &Options{
 				Path: "../testdata",
 			},
-			exclude: nil,
+			patterns: nil,
+			exclude:  nil,
 			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
 				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
 					t.Helper()
@@ -384,7 +428,8 @@ func Test_runCoverageAnalysis(t *testing.T) {
 			options: &Options{
 				Path: "/no/such/dir/that/does/not/exist",
 			},
-			exclude: nil,
+			patterns: nil,
+			exclude:  nil,
 			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
 				func(t *testing.T, _ []coverage.ModuleCoverage, err error) {
 					t.Helper()
@@ -398,7 +443,67 @@ func Test_runCoverageAnalysis(t *testing.T) {
 			options: &Options{
 				Path: "../testdata",
 			},
-			exclude: regexp.MustCompile(".*_test.go"),
+			patterns: nil,
+			exclude:  regexp.MustCompile(".*_test.go"),
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.NotEmpty(t, r)
+					for _, mc := range r {
+						for _, fn := range mc.Functions {
+							assert.NotContains(t, fn.File, "_test.go", "exclude pattern should filter test files")
+						}
+					}
+				},
+			},
+		},
+		{
+			name: "profile_based_scan",
+			options: &Options{
+				Path:            "../testdata",
+				CoverageProfile: "../testdata/cover.out",
+			},
+			patterns: nil,
+			exclude:  nil,
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.NotEmpty(t, r)
+					for _, mc := range r {
+						if mc.Error != nil {
+							t.Errorf("module %s had error: %v", mc.Dir, mc.Error)
+						}
+						assert.Equal(t, "../testdata/cover.out", mc.Profile)
+					}
+				},
+			},
+		},
+		{
+			name: "profile_nonexistent_returns_error",
+			options: &Options{
+				Path:            "../testdata",
+				CoverageProfile: "/no/such/profile.out",
+			},
+			patterns: nil,
+			exclude:  nil,
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, _ []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), "coverage scan")
+				},
+			},
+		},
+		{
+			name: "explicit_patterns_resolved_via_go_list",
+			options: &Options{
+				Path:         "../testdata",
+				IncludeTests: true,
+			},
+			patterns: []string{"../testdata"},
+			exclude:  nil,
 			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
 				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
 					t.Helper()
@@ -407,11 +512,98 @@ func Test_runCoverageAnalysis(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "path_only_no_patterns_uses_path_fallback",
+			options: &Options{
+				Path:         "../testdata",
+				IncludeTests: false,
+			},
+			patterns: nil,
+			exclude:  nil,
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.NotEmpty(t, r)
+					for _, mc := range r {
+						if mc.Error != nil {
+							t.Errorf("module %s had error: %v", mc.Dir, mc.Error)
+						}
+					}
+				},
+			},
+		},
+		{
+			name: "timeout_zero_uses_default",
+			options: &Options{
+				Path:         "../testdata",
+				IncludeTests: true,
+			},
+			patterns: nil,
+			exclude:  nil,
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.NotEmpty(t, r)
+				},
+			},
+		},
+		{
+			name: "include_tests_false_excludes_test_files",
+			options: &Options{
+				Path:         "../testdata",
+				IncludeTests: false,
+			},
+			patterns: nil,
+			exclude:  nil,
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.NotEmpty(t, r)
+					for _, mc := range r {
+						if mc.Error != nil {
+							t.Errorf("module %s had error: %v", mc.Dir, mc.Error)
+						}
+					}
+				},
+			},
+		},
+		{
+			name: "path_with_existing_profile_skips_go_list",
+			options: &Options{
+				Path:            "../testdata",
+				CoverageProfile: "../testdata/cover.out",
+				IncludeTests:    true,
+			},
+			patterns: nil,
+			exclude:  nil,
+			checks: []func(*testing.T, []coverage.ModuleCoverage, error){
+				func(t *testing.T, r []coverage.ModuleCoverage, err error) {
+					t.Helper()
+					assert.NoError(t, err)
+					assert.NotEmpty(t, r)
+					for _, mc := range r {
+						assert.NotEmpty(t, mc.Functions, "profile scan should have parsed functions")
+					}
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			r, err := runCoverageAnalysis(context.Background(), tt.options, tt.options.Patterns, tt.exclude, 0)
+			var ctx context.Context
+			var cancel context.CancelFunc
+			if tt.name == "context_cancelled_returns_context_error" {
+				ctx, cancel = context.WithCancel(context.Background())
+				cancel()
+			} else {
+				ctx, cancel = context.WithCancel(context.Background())
+				defer cancel()
+			}
+			r, err := runCoverageAnalysis(ctx, tt.options, tt.patterns, tt.exclude, 0)
 			for _, c := range tt.checks {
 				c(t, r, err)
 			}
@@ -449,6 +641,54 @@ func Test_parseMissingPolicy(t *testing.T) {
 		})
 	}
 }
+
+func Test_runCoverageAnalysis_resolveErrorNoPathFallback(t *testing.T) {
+	dir := t.TempDir()
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err = runCoverageAnalysis(ctx, &Options{}, []string{"./..."}, nil, 0)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "coverage scan: resolve patterns")
+	}
+}
+
+func Test_runComplexityAnalysis_resolveErrorNoPathFallback(t *testing.T) {
+	dir := t.TempDir()
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Suppress debug output from the logger.
+	l := &discardLogger{}
+	result := runComplexityAnalysis(ctx, &Options{Logger: l}, []string{"./..."}, nil)
+	assert.Empty(t, result)
+}
+
+type discardLogger struct{}
+
+func (discardLogger) Debug(_ string, _ ...any) {}
+func (discardLogger) Info(_ string, _ ...any)  {}
+func (discardLogger) Warn(_ string, _ ...any)  {}
+func (discardLogger) Error(_ string, _ ...any) {}
+func (discardLogger) Fatal(_ string, _ ...any) {}
 
 func Test_effectiveCRAP(t *testing.T) {
 	tests := []struct {
@@ -649,6 +889,269 @@ func Test_logCoverageErrors(t *testing.T) {
 
 			for _, c := range tt.checks {
 				c(t, got)
+			}
+		})
+	}
+}
+
+type groupTargetsFn func(*testing.T, []coverage.ModuleTarget)
+
+var checkgroupTargets = func(fns ...groupTargetsFn) []groupTargetsFn { return fns }
+
+var checkGroupTargetsLen = func(n int) groupTargetsFn {
+	return func(t *testing.T, mt []coverage.ModuleTarget) {
+		t.Helper()
+		assert.Lenf(t, mt, n, "groupTargets: expected %d module targets", n)
+	}
+}
+
+var checkGroupTargetsModule = func(modDir string, pkgDirs ...string) groupTargetsFn {
+	return func(t *testing.T, mt []coverage.ModuleTarget) {
+		t.Helper()
+		var found *coverage.ModuleTarget
+		for i := range mt {
+			if mt[i].ModDir == modDir {
+				found = &mt[i]
+				break
+			}
+		}
+		if !assert.NotNilf(t, found, "groupTargets: module %q not found in %+v", modDir, mt) {
+			return
+		}
+		assert.ElementsMatchf(t, pkgDirs, found.PkgDirs, "module %q pkg dirs mismatch", modDir)
+	}
+}
+
+func Test_groupTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []packages.Target
+		checks  []groupTargetsFn
+	}{
+		{
+			name:    "no targets",
+			targets: nil,
+			checks:  checkgroupTargets(checkGroupTargetsLen(0)),
+		},
+		{
+			name: "skips targets without module dir",
+			targets: []packages.Target{
+				{ImportPath: "example.com/foo", Dir: "/work/foo", ModuleDir: ""},
+			},
+			checks: checkgroupTargets(checkGroupTargetsLen(0)),
+		},
+		{
+			name: "single module single package",
+			targets: []packages.Target{
+				{ImportPath: "example.com/foo", Dir: "/mod/foo", ModulePath: "example.com", ModuleDir: "/mod"},
+			},
+			checks: checkgroupTargets(
+				checkGroupTargetsLen(1),
+				checkGroupTargetsModule("/mod", "/mod/foo"),
+			),
+		},
+		{
+			name: "single module multiple packages",
+			targets: []packages.Target{
+				{ImportPath: "example.com/a", Dir: "/mod/a", ModuleDir: "/mod"},
+				{ImportPath: "example.com/b", Dir: "/mod/b", ModuleDir: "/mod"},
+				{ImportPath: "example.com/c", Dir: "/mod/c", ModuleDir: "/mod"},
+			},
+			checks: checkgroupTargets(
+				checkGroupTargetsLen(1),
+				checkGroupTargetsModule("/mod", "/mod/a", "/mod/b", "/mod/c"),
+			),
+		},
+		{
+			name: "multiple modules",
+			targets: []packages.Target{
+				{ImportPath: "example.com/a", Dir: "/modA/a", ModuleDir: "/modA"},
+				{ImportPath: "example.com/b", Dir: "/modB/b", ModuleDir: "/modB"},
+			},
+			checks: checkgroupTargets(
+				checkGroupTargetsLen(2),
+				checkGroupTargetsModule("/modA", "/modA/a"),
+				checkGroupTargetsModule("/modB", "/modB/b"),
+			),
+		},
+		{
+			name: "mixed modules with skipped targets",
+			targets: []packages.Target{
+				{ImportPath: "example.com/standalone", Dir: "/solo", ModuleDir: ""},
+				{ImportPath: "example.com/a", Dir: "/mod/a", ModuleDir: "/mod"},
+				{ImportPath: "example.com/b", Dir: "/mod/b", ModuleDir: "/mod"},
+				{ImportPath: "example.com/other", Dir: "/other", ModuleDir: "/other"},
+			},
+			checks: checkgroupTargets(
+				checkGroupTargetsLen(2),
+				checkGroupTargetsModule("/mod", "/mod/a", "/mod/b"),
+				checkGroupTargetsModule("/other", "/other"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := groupTargets(tt.targets)
+			for _, c := range tt.checks {
+				c(t, r)
+			}
+		})
+	}
+}
+
+type runComplexityAnalysisFn func(*testing.T, []complexity.Stat)
+
+var checkrunComplexityAnalysis = func(fns ...runComplexityAnalysisFn) []runComplexityAnalysisFn { return fns }
+
+var checkComplexityLen = func(n int) runComplexityAnalysisFn {
+	return func(t *testing.T, stats []complexity.Stat) {
+		t.Helper()
+		assert.Lenf(t, stats, n, "runComplexityAnalysis: expected %d stats", n)
+	}
+}
+
+var checkComplexityContains = func(name string) runComplexityAnalysisFn {
+	return func(t *testing.T, stats []complexity.Stat) {
+		t.Helper()
+		for _, s := range stats {
+			if s.FuncName == name {
+				return
+			}
+		}
+		t.Errorf("runComplexityAnalysis: expected stat %q in %+v", name, stats)
+	}
+}
+
+var checkComplexityNotContains = func(name string) runComplexityAnalysisFn {
+	return func(t *testing.T, stats []complexity.Stat) {
+		t.Helper()
+		for _, s := range stats {
+			assert.NotEqualf(t, name, s.FuncName, "runComplexityAnalysis: unexpected stat %q", name)
+		}
+	}
+}
+
+var checkComplexityEmpty = func() runComplexityAnalysisFn {
+	return func(t *testing.T, stats []complexity.Stat) {
+		t.Helper()
+		assert.Emptyf(t, stats, "runComplexityAnalysis: expected no stats")
+	}
+}
+
+var checkComplexityLenGreaterThan = func(n int) runComplexityAnalysisFn {
+	return func(t *testing.T, stats []complexity.Stat) {
+		t.Helper()
+		assert.Greaterf(t, len(stats), n, "runComplexityAnalysis: expected >%d stats, got %d", n, len(stats))
+	}
+}
+
+func Test_runComplexityAnalysis(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  *Options
+		patterns []string
+		exclude  *regexp.Regexp
+		checks   []runComplexityAnalysisFn
+	}{
+		{
+			name:   "resolve_success_returns_stats",
+			options: &Options{
+				IncludeTests: false,
+			},
+			patterns: []string{"."},
+			checks: checkrunComplexityAnalysis(
+				checkComplexityLen(20),
+				checkComplexityContains("Scan"),
+				checkComplexityContains("runComplexityAnalysis"),
+				checkComplexityContains("NewEntries"),
+			),
+		},
+		{
+			name:   "include_tests_true_appends_test_stats",
+			options: &Options{
+				IncludeTests: true,
+			},
+			patterns: []string{"."},
+			checks: checkrunComplexityAnalysis(
+				checkComplexityContains("TestScan"),
+				checkComplexityContains("Test_groupTargets"),
+				checkComplexityLenGreaterThan(10),
+			),
+		},
+		{
+			name:    "exclude_pattern_filters_functions",
+			options: &Options{
+				IncludeTests: false,
+			},
+			patterns: []string{"."},
+			exclude:  regexp.MustCompile("runComplexityAnalysis"),
+			checks: checkrunComplexityAnalysis(
+				checkComplexityLen(19),
+				checkComplexityNotContains("runComplexityAnalysis"),
+				checkComplexityContains("Scan"),
+			),
+		},
+		{
+			name:    "exclude_test_files_filters_file_paths",
+			options: &Options{
+				IncludeTests: true,
+			},
+			patterns: []string{"."},
+			exclude:  regexp.MustCompile(`_test\.go`),
+			checks: checkrunComplexityAnalysis(
+				checkComplexityLen(20),
+				checkComplexityNotContains("TestScan"),
+				checkComplexityNotContains("Test_groupTargets"),
+			),
+		},
+		{
+			name:   "resolve_error_path_fallback_walks_directory",
+			options: &Options{
+				IncludeTests: true,
+				Path:         "../testdata",
+			},
+			patterns: []string{"../testdata"},
+			checks: checkrunComplexityAnalysis(
+				checkComplexityLen(6),
+				checkComplexityContains("veryComplex"),
+				checkComplexityContains("withSwitch"),
+				checkComplexityContains("simple"),
+				checkComplexityContains("withIf"),
+				checkComplexityContains("complex"),
+				checkComplexityContains("TestSimple"),
+			),
+		},
+		{
+			name:    "path_fallback_excludes_test_files",
+			options: &Options{
+				IncludeTests: true,
+				Path:         "../testdata",
+			},
+			patterns: []string{"../testdata"},
+			exclude:  regexp.MustCompile(`_test\.go`),
+			checks: checkrunComplexityAnalysis(
+				checkComplexityLen(5),
+				checkComplexityNotContains("TestSimple"),
+				checkComplexityContains("veryComplex"),
+				checkComplexityContains("simple"),
+			),
+		},
+		{
+			name:   "resolve_error_without_path_returns_empty",
+			options: &Options{
+				IncludeTests: false,
+			},
+			patterns: []string{"../nonexistent/..."},
+			checks: checkrunComplexityAnalysis(checkComplexityEmpty()),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := runComplexityAnalysis(context.Background(), tt.options, tt.patterns, tt.exclude)
+			for _, c := range tt.checks {
+				c(t, r)
 			}
 		})
 	}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor
- [ ] CI/CD

## Description

Adds support for scanning multiple Go package patterns using go list / go build syntax. scan now accepts any number of positional args (scan [pattern ...]), e.g. go-crap scan ./internal/foo ./internal/bar, and defaults to ./... (whole module) when none are given.

### Internals:
- New internal/packages module resolves patterns via go list (Resolve, getTargets, getList), replacing the single-path resolver.
- internal/coverage.Scanner.Scan and internal/scan wired to expand patterns into per-package targets.
- internal/complexity.AnalyzeFiles extended to analyze multiple files per target.

**Tests added:** packages, runner, scan, scanner, analyze (≈2000 lines). Regression fails reduced to zero.

**Docs updated:** README, doc/docs/commands/scan.md, quickstart, index — new pattern table, multi-package and import-path examples, updated Docker usage.

## Related issues

Closes #41 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] Tests added for new functionality
- [x] Documentation updated if needed
